### PR TITLE
Rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2025-02-10
+
+- Rename `keywords` to `search_phrases`, `include_keywords` to `keywords` and `exclude_keywords` to `antikeywords` [#45]
+- Separate statistics by item name [#46]
+
 ## [0.7.3] - 2025-02-07
 
 - Allow email notification

--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ date_listed = ["all", "last 24 hours"]
 
 _ai-marketplace-monitor_ shows statistics such as the number of pages searched, number of listings examined and excluded, number of matching lists found and number of users notified when you exit the program. If you would like to see the statistics during monitoring, press `Esc` and wait till the current search to end.
 
+Counters are persistent across program runs. If you would like to reset the counters, use
+
+```
+ai-marketplace-monitor --clear-cache counters
+```
+
 ### Self-hosted Ollama Model
 
 If you have access to a decent machine and prefer not to pay for AI services from OpenAI or other vendors. You can opt to install Ollama locally and access it using the `provider = "ollama"`. If you have ollama on your local host, you can use
@@ -416,6 +422,7 @@ to clear the cache. The following cache types are supported
 - `listing-details`
 - `ai-inquiries`
 - `user-notification`
+- `counters`
 
 `--clear-cache all` is also possible but not recommended.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ One or more configuration file in [TOML format](https://toml.io/en/) is needed. 
 search_city = 'houston'
 
 [item.name]
-keywords = 'Go Pro Hero 11'
+search_phrases = 'Go Pro Hero 11'
 
 [user.user1]
 pushbullet_token = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -160,7 +160,7 @@ seller_locations = [
 ]
 
 [item.name]
-keywords = 'Go Pro Hero 11'
+search_phrases = 'Go Pro Hero 11'
 description = '''A new or used Go Pro version 11, 12 or 13 in
     good condition. No other brand of camera is acceptable.
     Please exclude sellers who offers shipping or asks to
@@ -169,7 +169,7 @@ min_price = 100
 max_price = 200
 
 [item.name2]
-keywords = 'something rare'
+search_phrases = 'something rare'
 description = '''A rare item that has to be searched nationwide and be shipped.
     listings from any location are acceptable.'''
 search_region = 'usa'
@@ -362,15 +362,15 @@ seller_location = []
 delivery_method = 'shipping'
 
 [item.default_item]
-keywords = 'local item for default market "facebook"'
+search_phrases = 'local item for default market "facebook"'
 
 [item.rare_item1]
 marketplace = 'nationwide'
-keywords = 'rare item1'
+search_phrases = 'rare item1'
 
 [item.rare_item2]
 marketplace = 'nationwide'
-keywords = 'rare item2'
+search_phrases = 'rare item2'
 ```
 
 ### First and subsequent searches

--- a/conftest.py
+++ b/conftest.py
@@ -42,10 +42,9 @@ def item_config() -> FacebookItemConfig:
         name="test",
         description="long description",
         enabled=True,
-        exclude_by_description=["some exclude1", "some exclude2"],
-        exclude_keywords=["exclude1", "exclude2"],
-        include_keywords=["exclude1", "exclude2"],
-        keywords=["search word one"],
+        antikeywords=["exclude1", "exclude2"],
+        keywords=["include1", "include2"],
+        search_phrases=["search word one"],
         marketplace="facebook",
         search_city=["houston"],
         # the following are common options

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,4 +1,6 @@
-## Table of content:
+## Configuration Guide
+
+### Table of content:
 
 - [AI Agents](#ai-agents)
 - [Marketplaces](#marketplaces)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -90,22 +90,21 @@ See [Setting up email notification](#setting-up-email-notification) for details 
 
 One or more `item.item_name` where `item_name` is the name of the item.
 
-| Option                   | Requirement | DataType    | Description                                                                                                                                                                                    |
-| ------------------------ | ----------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keywords`               | Required    | String/List | One or more strings for searching the item.                                                                                                                                                    |
-| `description`            | Optional    | String      | A longer description of the item that better describes your requirements (e.g., manufacture, condition, location, seller reputation, shipping options). Only used if AI assistance is enabled. |
-| `enabled`                | Optional    | Boolean     | Stops searching this item if set to `false`.                                                                                                                                                   |
-| `include_keywords`       | Optional    | String/List | Excludes listings that do not contain any of the keywords.                                                                                                                                     |
-| `exclude_keywords`       | Optional    | String/List | Excludes listings whose titles contain any of the specified strings.                                                                                                                           |
-| `exclude_by_description` | Optional    | String/List | Excludes items with descriptions containing any of the specified strings.                                                                                                                      |
-| `marketplace`            | Optional    | String      | Name of the marketplace, default to `facebook` that points to a `marketplace.facebook` sectiion.                                                                                               |
-| **Common options**       |             |             | Options listed below. These options, if specified in the item section, will override options in the marketplace section.                                                                       |
+| Option             | Requirement | DataType    | Description                                                                                                                                                                                    |
+| ------------------ | ----------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search_phrases`   | Required    | String/List | One or more strings for searching the item.                                                                                                                                                    |
+| `description`      | Optional    | String      | A longer description of the item that better describes your requirements (e.g., manufacture, condition, location, seller reputation, shipping options). Only used if AI assistance is enabled. |
+| `enabled`          | Optional    | Boolean     | Stops searching this item if set to `false`.                                                                                                                                                   |
+| `keywords`         | Optional    | String/List | Excludes listings whose titles and description do not contain any of the keywords.                                                                                                             |
+| `antikeywords`     | Optional    | String/List | Excludes listings whose titles or descriptions contain any of the specified keywords.                                                                                                          |
+| `marketplace`      | Optional    | String      | Name of the marketplace, default to `facebook` that points to a `marketplace.facebook` sectiion.                                                                                               |
+| **Common options** |             |             | Options listed below. These options, if specified in the item section, will override options in the marketplace section.                                                                       |
 
-Marketplaces may return listings that are completely unrelated to search keywords, but can also
+Marketplaces may return listings that are completely unrelated to search search_phrases, but can also
 return related items under different names. To select the right items, you can
 
-1. Use `include_keywords` to keep only items with certain words in the title. For example, you can set `include_keywords = ['gopro', 'go pro']` when you search for `keywords = 'gopro'`.
-2. Use `exclude_keywords` to narrow down the search. For example, setting `exclude_keywords=['HERO 4']` will exclude items with `HERO 4` or `hero 4`in the title.
+1. Use `keywords` to keep only items with certain words in the title. For example, you can set `include_search_phrases = ['gopro', 'go pro']` when you search for `search_phrases = 'gopro'`.
+2. Use `antikeywords` to narrow down the search. For example, setting `antikeywords=['HERO 4']` will exclude items with `HERO 4` or `hero 4`in the title or description.
 3. It is usually more effective to write a longer `description` and let the AI know what exactly you want. This will make sure that you will not get a drone when you are looking for a `DJI` camera. It is still a good idea to pre-filter listings using non-AI criteria to reduce the cost of AI services.
 
 ### Options that can be specified for both marketplaces and items

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -103,7 +103,7 @@ One or more `item.item_name` where `item_name` is the name of the item.
 Marketplaces may return listings that are completely unrelated to search search_phrases, but can also
 return related items under different names. To select the right items, you can
 
-1. Use `keywords` to keep only items with certain words in the title. For example, you can set `include_search_phrases = ['gopro', 'go pro']` when you search for `search_phrases = 'gopro'`.
+1. Use `keywords` to keep only items with certain words in the title. For example, you can set `keywords = ['gopro', 'go pro']` when you search for `search_phrases = 'gopro'`.
 2. Use `antikeywords` to narrow down the search. For example, setting `antikeywords=['HERO 4']` will exclude items with `HERO 4` or `hero 4`in the title or description.
 3. It is usually more effective to write a longer `description` and let the AI know what exactly you want. This will make sure that you will not get a drone when you are looking for a `DJI` camera. It is still a good idea to pre-filter listings using non-AI criteria to reduce the cost of AI services.
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -12,7 +12,6 @@ max_search_interval = '1h'
 seller_locations = ['city', 'surrounding city']
 notify = 'user1'
 exclude_sellers = []
-exclude_by_description = []
 
 [notify.user1]
 pushbullet_token = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -27,19 +26,18 @@ smtp_username = 'myself@gmail.com'
 smtp_password = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
 [item.name1]
-keywords = 'search word one'
+search_phrases = 'search word one'
 search_region = 'usa'
 search_interval = '1d'
 delivery_method = 'shipping'
 seller_locations = []
 
 [item.name2]
-keywords = ['search word one', 'search word two']
+search_phrases = ['search word one', 'search word two']
 description = "it should be from manufacture, the seller should not offer shipping."
-include_keywords = ['search word']
-exclude_keywords = ['exclude word one', 'exclude word two']
+keywords = ['search word']
+antikeywords = ['exclude word one', 'exclude word two']
 notify = 'user2'
 search_city = 'another city'
 seller_locations = ['another city', 'surrounding city']
 exclude_sellers = []
-exclude_by_description = []

--- a/minimal_config.toml
+++ b/minimal_config.toml
@@ -3,7 +3,7 @@ username = 'username@gmail.com'
 search_city = 'houston'
 
 [item.name1]
-keywords = 'search word one'
+search_phrases = 'search word one'
 
 [user.user1]
 pushbullet_token = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -177,10 +177,8 @@ class AIBackend(Generic[TAIConfig]):
         elif min_price:
             prompt += f"""Min price {min_price}. """
         #
-        if item_config.exclude_keywords:
-            prompt += f"""Exclude keywords "{'" and "'.join(item_config.exclude_keywords)}"."""
-        if item_config.exclude_by_description:
-            prompt += f"""Exclude description with: "{'" and "'.join(item_config.exclude_by_description)}"."""
+        if item_config.antikeywords:
+            prompt += f"""Exclude keywords "{'" and "'.join(item_config.antikeywords)}" in title or description."""
         #
         prompt += (
             f"""\n\nThe user found a listing titled "{listing.title}" in {listing.condition} condition, """

--- a/src/ai_marketplace_monitor/email.html.j2
+++ b/src/ai_marketplace_monitor/email.html.j2
@@ -104,7 +104,7 @@
         <table width="100%" cellpadding="0" cellspacing="0" border="0">
             <tr>
                 <td class="content">
-                    <h2>Latest Listings</h2>
+                    <h2>Latest {{ item_name }} Listings</h2>
                     <table class="listing-table" cellpadding="0" cellspacing="0" border="0">
                         {% for listing, rating, ns in listings %}
                         <tr>
@@ -114,14 +114,14 @@
                                     <h3 style="color: #2C5364; font-size: 18px; font-weight: bold; margin: 0; display: inline;">
                                         {{ listing.title }}
                                     </h3>
-                                    {% if ns.value == 'NOT_NOTIFIED' %}
+                                    {% if ns == NotificationStatus.NOT_NOTIFIED %}
                                         <span class="status-tag status-new">NEW</span>
-                                    {% elif ns.value == 'LISTING_CHANGED' %}
+                                    {% elif ns == NotificationStatus.LISTING_CHANGED %}
                                         <span class="status-tag status-updated">UPDATED</span>
-                                    {% elif ns.value == 'EXPIRED' %}
-                                        <span class="status-tag status-expired">EXPIRED</span>
-                                    {% elif ns.value == 'NOTIFIED' and force %}
-                                        <span class="status-tag status-sent">NOTIFIED</span>
+                                    {% elif ns == NotificationStatus.EXPIRED %}
+                                        <span class="status-tag status-expired">REVISITABLE</span>
+                                    {% elif ns == NotificationStatus.NOTIFIED and force %}
+                                        <span class="status-tag status-sent">REVISITABLE</span>
                                     {% endif %}
                                 </div>
 

--- a/src/ai_marketplace_monitor/marketplace.py
+++ b/src/ai_marketplace_monitor/marketplace.py
@@ -237,15 +237,40 @@ class ItemConfig(MarketItemCommonConfig):
     searched_count: int = 0
 
     # keywords is required, all others are optional
-    keywords: List[str] = field(default_factory=list)
-    include_keywords: List[str] | None = None
-    exclude_keywords: List[str] | None = None
-    exclude_by_description: List[str] | None = None
+    search_phrases: List[str] = field(default_factory=list)
+    keywords: List[str] | None = None
+    antikeywords: List[str] | None = None
     description: str | None = None
     enabled: bool | None = None
     marketplace: str | None = None
 
+    def handle_search_phrases(self: "ItemConfig") -> None:
+        if isinstance(self.search_phrases, str):
+            self.search_phrases = [self.search_phrases]
+
+        if not isinstance(self.search_phrases, list) or not all(
+            isinstance(x, str) for x in self.search_phrases
+        ):
+            raise ValueError(f"Item {hilight(self.name)} search_phrases must be a list.")
+        if len(self.search_phrases) == 0:
+            raise ValueError(f"Item {hilight(self.name)} search_phrases list is empty.")
+
+    def handle_antikeywords(self: "ItemConfig") -> None:
+        if self.antikeywords is None:
+            return
+
+        if isinstance(self.antikeywords, str):
+            self.antikeywords = [self.antikeywords]
+
+        if not isinstance(self.antikeywords, list) or not all(
+            isinstance(x, str) for x in self.antikeywords
+        ):
+            raise ValueError(f"Item {hilight(self.name)} antikeywords must be a list of strings.")
+
     def handle_keywords(self: "ItemConfig") -> None:
+        if self.keywords is None:
+            return
+
         if isinstance(self.keywords, str):
             self.keywords = [self.keywords]
 
@@ -253,34 +278,6 @@ class ItemConfig(MarketItemCommonConfig):
             isinstance(x, str) for x in self.keywords
         ):
             raise ValueError(f"Item {hilight(self.name)} keywords must be a list.")
-        if len(self.keywords) == 0:
-            raise ValueError(f"Item {hilight(self.name)} keywords list is empty.")
-
-    def handle_exclude_keywords(self: "ItemConfig") -> None:
-        if self.exclude_keywords is None:
-            return
-
-        if isinstance(self.exclude_keywords, str):
-            self.exclude_keywords = [self.exclude_keywords]
-
-        if not isinstance(self.exclude_keywords, list) or not all(
-            isinstance(x, str) for x in self.exclude_keywords
-        ):
-            raise ValueError(
-                f"Item {hilight(self.name)} exclude_keywords must be a list of strings."
-            )
-
-    def handle_include_keywords(self: "ItemConfig") -> None:
-        if self.include_keywords is None:
-            return
-
-        if isinstance(self.include_keywords, str):
-            self.include_keywords = [self.include_keywords]
-
-        if not isinstance(self.include_keywords, list) or not all(
-            isinstance(x, str) for x in self.include_keywords
-        ):
-            raise ValueError(f"Item {hilight(self.name)} include_keywords must be a list.")
 
     def handle_description(self: "ItemConfig") -> None:
         if self.description is None:
@@ -293,16 +290,6 @@ class ItemConfig(MarketItemCommonConfig):
             return
         if not isinstance(self.enabled, bool):
             raise ValueError(f"Item {hilight(self.name)} enabled must be a boolean.")
-
-    def handle_exclude_by_description(self: "ItemConfig") -> None:
-        if self.exclude_by_description is None:
-            return
-        if isinstance(self.exclude_by_description, str):
-            self.exclude_by_description = [self.exclude_by_description]
-        if not isinstance(self.exclude_by_description, list) or not all(
-            isinstance(x, str) for x in self.exclude_by_description
-        ):
-            raise ValueError(f"Item {hilight(self.name)} exclude_by_description must be a list.")
 
 
 TMarketplaceConfig = TypeVar("TMarketplaceConfig", bound=MarketplaceConfig)

--- a/src/ai_marketplace_monitor/monitor.py
+++ b/src/ai_marketplace_monitor/monitor.py
@@ -547,9 +547,9 @@ class MarketplaceMonitor:
                             )
 
                     # testing notification
-                    # User(self.config.user[user], logger=self.logger).notify(
-                    #     [listing], [rating], force=True
-                    # )
+                    User(self.config.user[user], logger=self.logger).notify(
+                        [listing], [rating], force=True
+                    )
 
     def evaluate_by_ai(
         self: "MarketplaceMonitor",

--- a/src/ai_marketplace_monitor/smtp.py
+++ b/src/ai_marketplace_monitor/smtp.py
@@ -81,12 +81,10 @@ class SMTPConfig(BaseConfig):
         cnts = []
         if n_new > 0:
             cnts.append(f"{n_new} new ")
-        if n_expired > 0:
-            cnts.append(f"{n_expired} expired ")
         if n_updated > 0:
             cnts.append(f"{n_updated} updated ")
-        if force and n_notified > 0:
-            cnts.append(f"{n_notified} notified ")
+        if n_expired > 0 or (force and n_notified > 0):
+            cnts.append(f"{n_expired + (n_notified if force else 0)} revisitable ")
         if len(cnts) > 1:
             cnts[-1] = f"and {cnts[-1]}"
         elif len(cnts) == 0:
@@ -94,7 +92,7 @@ class SMTPConfig(BaseConfig):
             return ""
 
         title += " ".join(cnts)
-        title += f"{p.plural_noun(listings[0].name, len(listings)-(0 if force else n_notified))} from {listings[0].marketplace}"
+        title += f"{listings[0].name} {p.plural_noun('listing', len(listings)-(0 if force else n_notified))} from {listings[0].marketplace}"
         return title
 
     def get_text_message(
@@ -181,6 +179,7 @@ class SMTPConfig(BaseConfig):
         html = template.render(
             listings=zip(listings, ratings, notification_status),
             force=force,
+            item_name=listings[0].name.capitalize(),
             NotificationStatus=NotificationStatus,  # Pass enum for comparison
             valid_image_hashes=valid_image_hashes,  # Pass set of valid image hashes
         )

--- a/src/ai_marketplace_monitor/user.py
+++ b/src/ai_marketplace_monitor/user.py
@@ -8,6 +8,7 @@ from diskcache import Cache  # type: ignore
 
 from .ai import AIResponse  # type: ignore
 from .listing import Listing
+from .marketplace import TItemConfig
 from .pushbullet import PushbulletConfig
 from .smtp import SMTPConfig
 from .utils import (
@@ -153,6 +154,7 @@ class User:
         self: "User",
         listings: List[Listing],
         ratings: List[AIResponse],
+        item_config: TItemConfig,
         local_cache: Cache | None = None,
         force: bool = False,
     ) -> None:
@@ -162,7 +164,7 @@ class User:
         ) or self.config.notify_through_email(
             self.config.email, listings, ratings, statuses, force=force, logger=self.logger
         ):
-            counter.increment(CounterItem.NOTIFICATIONS_SENT)
+            counter.increment(CounterItem.NOTIFICATIONS_SENT, item_config.name)
             for listing, ns in zip(listings, statuses):
                 if self.logger:
                     if ns == NotificationStatus.NOTIFIED:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,17 +73,16 @@ search_region = 'usa'
 
 base_item_cfg = """
 [item.name]
-keywords = 'search word one'
+search_phrases = 'search word one'
 """
 
 full_item_cfg = """
 [item.name]
+antikeywords = ['exclude1', 'exclude2']
 description = 'long description'
 enabled = true
-exclude_by_description = ['some exclude1', 'some exclude2']
-exclude_keywords = ['exclude1', 'exclude2']
-include_keywords = ['exclude1', 'exclude2']
-keywords = 'search word one'
+keywords = ['exclude1', 'exclude2']
+search_phrases = 'search word one'
 marketplace = 'facebook'
 search_city = 'houston'
 # the following are common options
@@ -166,11 +165,9 @@ def test_config(config_file: Callable, config_content: str, acceptable: bool) ->
         "delivery_method": (list, type(None)),
         "description": (str, type(None)),
         "enabled": (bool, type(None)),
-        "exclude_by_description": (list, type(None)),
-        "exclude_keywords": (list, type(None)),
+        "antikeywords": (list, type(None)),
         "exclude_sellers": (list, type(None)),
         "keywords": (list, type(None)),
-        "include_keywords": (list, type(None)),
         "login_wait_time": (int, type(None)),
         "marketplace": (str, type(None)),
         "max_price": (int, type(None)),
@@ -187,6 +184,7 @@ def test_config(config_file: Callable, config_content: str, acceptable: bool) ->
         "remind": (int, type(None)),
         "search_city": (list, type(None)),
         "search_interval": (int, type(None)),
+        "search_phrases": list,
         "search_region": (list, type(None)),
         "searched_count": int,
         "start_at": (list, type(None)),
@@ -219,7 +217,7 @@ search_city = 'houston'
 alt_item_cfg = """
 [item.whatever]
 marketplace = "houston"
-keywords = "search word two"
+search_phrases = "search word two"
 """
 
 


### PR DESCRIPTION
Fixes #45 , #46

## Proposed Changes

  - rename `keywords` to `search_phrases`
  - rename `include_keywords` to `keywords` and test both title and description
  - rename `exclude_keywrods` to `antikeywords` and test both title and description
  - remove option `exclude_by_description`.
  - separate statistics by items searched.
