### PR TITLE
Reorganize-notification settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2025-03-02
 
 - Reorganize notification settings
+- Support the use of environment variables for passwords
 
 **BREAKING CHANGES**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-03-02
+
+- Reorganize notification settings
+- Allow [pushover](https://pushover.net/) notification
+
 ## [0.7.11] - 2025-03-01
 
 - Fix a bug on the handling of logical expressions for `keywords` and `antikeywords`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2025-03-02
 
 - Reorganize notification settings
-- Allow [pushover](https://pushover.net/) notification
 
 **BREAKING CHANGES**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorganize notification settings
 - Allow [pushover](https://pushover.net/) notification
 
+**BREAKING CHANGES**
+
+- Rename `smtp` sections to `notification`
+- Rename parameter `smtp` to `notify_with`
+
 ## [0.7.11] - 2025-03-01
 
 - Fix a bug on the handling of logical expressions for `keywords` and `antikeywords`.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ playwright install
 
 If you would like to receive notification from your phone via PushBullet or PushOver
 
-- Sign up for [PushBullet](https://www.pushbullet.com/) or [PushOver](https://pushover.net/)
+- Sign up for [PushBullet](https://www.pushbullet.com/)
 - Install the app on your phone
 - Go to the PushBullet or PushOver website and obtain necessary token(s)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AI: Great deal; A well-priced, well-maintained camera meets all search criteria,
 - [Usage](#usage)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
-  - [Set up PushBullet (optional)](#set-up-pushbullet-optional)
+  - [Set up a notification method (optional)](#set-up-a-notification-method-optional)
   - [Sign up with an AI service or build your own (optional)](#sign-up-with-an-ai-service-or-build-your-own-optional)
   - [Configuration](#configuration)
   - [Run the program](#run-the-program)
@@ -77,7 +77,7 @@ AI: Great deal; A well-priced, well-maintained camera meets all search criteria,
 
 📱 **Notifications**
 
-- PushBullet notifications
+- PushBullet and PushOver notifications
 - HTML email notifications with images
 - Customizable notification levels
 - Repeated notification options
@@ -110,13 +110,15 @@ Install a browser for Playwright using the command:
 playwright install
 ```
 
-### Set up PushBullet (optional)
+### Set up a notification method (optional)
 
-If you would like to receive notification through phone notification
+If you would like to receive notification from your phone via PushBullet or PushOver
 
-- Sign up for [PushBullet](https://www.pushbullet.com/)
+- Sign up for [PushBullet](https://www.pushbullet.com/) or [PushOver](https://pushover.net/)
 - Install the app on your phone
-- Go to the PushBullet website and obtain a token
+- Go to the PushBullet or PushOver website and obtain necessary token(s)
+
+If you would like to receive email notification, obtain relevant SMTP settings from your email provider. See [Setting up email notification](#setting-up-email-notification) for details.
 
 ### Sign up with an AI service or build your own (optional)
 
@@ -207,13 +209,13 @@ It is recommended that you **check the log messages and make sure that it includ
 ### Cost of operations
 
 1. _AI Markplace Monitor_ is distributed under an MIT license. You are free to use, modify, and even use the program for commercial purposes.
-2. While the program itself is free, access to optional external services such as PushBullet, OpenAI, DeepSeek, or other AI services may incur costs.
+2. While the program itself is free, access to optional external services such as PushBullet, PushOver, OpenAI, DeepSeek, or other AI services may incur costs.
 
 ## Advanced features
 
 ### Setting up email notification
 
-Sending email notifications requires recipient email addresses, which are specified in `email` of `user`. For example, you can send email notifications to multiple users with multiple email addresses as
+Sending email notifications requires recipient email addresses, which are specified in `email` of `user` or a notification setting. For example, you can send email notifications to multiple users with multiple email addresses as
 
 ```toml
 [user.user1]
@@ -223,16 +225,28 @@ email = 'user1@gmail.com'
 email = ['user2@gmail.com', 'user2@outlook.com']
 ```
 
-You then need a SMTP server that helps you to send the emails, for which you will need to know `smtp_server`, `smtp_port`, `smtp_username` and `smtp_password`. Generally speaking, you will need to create an `smtp` section with the information obtained from your email service provider.
+You then need a SMTP server that helps you to send the emails, for which you will need to know `smtp_server`, `smtp_port`, `smtp_username` and `smtp_password`. Generally speaking, you will need to create a notification section with the information obtained from your email service provider.
 
 ```toml
-[smtp.myprovider]
+[notification.myprovider]
 # default to sender email
 smtp_username = 'username@EMAIL.COM'
 # default to smtp.EMAIL.COM
 smtp_server = 'smtp.EMAIL.COM'
 smtp_port = 587
 smtp_password = 'mypassword'
+```
+
+and add the settings to the `user` sections as
+
+```toml
+[user.user1]
+email = 'user1@gmail.com'
+notify_with = 'myprovider'
+
+[user.user2]
+email = ['user2@gmail.com', 'user2@outlook.com']
+notify_with = 'myprovider'
 ```
 
 `ai-marketplace-monitor` will try to determine `smtp_username` and `smtp_server` from the sender email address if they are unspecified.
@@ -246,7 +260,7 @@ If you have a GMAIL account,
 That is to say, you `smtp` setting for your gmail account should look like
 
 ```toml
-[smtp.gmail]
+[notification.gmail]
 smtp_username = 'myemail@gmail.com'
 smtp_password = 'abcdefghijklmnop'
 ```
@@ -552,7 +566,7 @@ Although I certainly do not have the bandwidth to support all possible layouts, 
 
    - Check `rating` level if receiving too many/few alerts
    - For email issues, verify SMTP settings and credentials
-   - For PushBullet, verify token is correct
+   - For PushBullet or PushOver, verify token is correct
 
 3. **AI Services**
    - Ensure API keys are valid

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ AI: Great deal; A well-priced, well-maintained camera meets all search criteria,
 
 📱 **Notifications**
 
-- PushBullet and PushOver notifications
+- PushBullet notifications
 - HTML email notifications with images
 - Customizable notification levels
 - Repeated notification options
@@ -112,11 +112,11 @@ playwright install
 
 ### Set up a notification method (optional)
 
-If you would like to receive notification from your phone via PushBullet or PushOver
+If you would like to receive notification from your phone via PushBullet
 
 - Sign up for [PushBullet](https://www.pushbullet.com/)
 - Install the app on your phone
-- Go to the PushBullet or PushOver website and obtain necessary token(s)
+- Go to the PushBullet website and obtain necessary token(s)
 
 If you would like to receive email notification, obtain relevant SMTP settings from your email provider. See [Setting up email notification](#setting-up-email-notification) for details.
 
@@ -209,7 +209,7 @@ It is recommended that you **check the log messages and make sure that it includ
 ### Cost of operations
 
 1. _AI Markplace Monitor_ is distributed under an MIT license. You are free to use, modify, and even use the program for commercial purposes.
-2. While the program itself is free, access to optional external services such as PushBullet, PushOver, OpenAI, DeepSeek, or other AI services may incur costs.
+2. While the program itself is free, access to optional external services such as PushBullet, OpenAI, DeepSeek, or other AI services may incur costs.
 
 ## Advanced features
 
@@ -554,7 +554,7 @@ Although I certainly do not have the bandwidth to support all possible layouts, 
 
    - Check `rating` level if receiving too many/few alerts
    - For email issues, verify SMTP settings and credentials
-   - For PushBullet or PushOver, verify token is correct
+   - For PushBullet, verify token is correct
 
 3. **AI Services**
    - Ensure API keys are valid

--- a/README.md
+++ b/README.md
@@ -237,18 +237,6 @@ smtp_port = 587
 smtp_password = 'mypassword'
 ```
 
-and add the settings to the `user` sections as
-
-```toml
-[user.user1]
-email = 'user1@gmail.com'
-notify_with = 'myprovider'
-
-[user.user2]
-email = ['user2@gmail.com', 'user2@outlook.com']
-notify_with = 'myprovider'
-```
-
 `ai-marketplace-monitor` will try to determine `smtp_username` and `smtp_server` from the sender email address if they are unspecified.
 
 If you have a GMAIL account,

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@
 
 The AI Marketplace Monitor uses [TOML](https://toml.io/en/) configuration files to control its behavior. The system will always check for a configuration file at `~/.ai-marketplace-monitor/config.toml`. You can specify additional configuration files using the `--config` option.
 
+To avoid including sensitive information directly in the configuration file, certain options can be specified using the `${ENV_VAR}` format (e.g., `${FACEBOOK_PASSWORD}`). _AI Marketplace Monitor_ will then retrieve the value from the corresponding environment variable if available.
+
 Here is a complete list of options that are acceptable by the program. [`example_config.toml`](example_config.toml) provides an example with many of the options.
 
 ### AI Services
@@ -51,8 +53,8 @@ One or more sections `marketplace.name` show the options for interacting with va
 | Option            | Requirement | DataType | Description                                                                                       |
 | ----------------- | ----------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `market_type`     | Optional    | String   | The supported marketplace. Currently, only `facebook` is supported.                               |
-| `username`        | Optional    | String   | Username can be entered manually or kept in the config file.                                      |
-| `password`        | Optional    | String   | Password can be entered manually or kept in the config file.                                      |
+| `username`        | Optional    | String   | Username can be entered manually or kept in the config file. Can be specified via `${ENV_VAR}`.   |
+| `password`        | Optional    | String   | Password can be entered manually or kept in the config file. Can be specified via `${ENV_VAR}`.   |
 | `login_wait_time` | Optional    | Integer  | Time (in seconds) to wait before searching to allow enough time to enter CAPTCHA. Defaults to 60. |
 
 | **Common options** | | | Options listed in the [Common options](#common-options) section below that provide default values for all items. |
@@ -138,32 +140,30 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 
 #### Pushbullet notification
 
-| Option                    | Requirement | DataType | Description                           |
-| ------------------------- | ----------- | -------- | ------------------------------------- |
-| `type`                    | Optional    | String   | Can only be `pushbullet` if specified |
-| `pushbullet_token`        | Optional    | String   | Token for user                        |
-| `pushbullet_proxy_type`   | Optional    | String   | HTTP proxy type, e.g. `https`         |
-| `pushbullet_proxy_server` | Optional    | String   | HTTP proxy server URL                 |
+| Option                    | Requirement | DataType | Description                                        |
+| ------------------------- | ----------- | -------- | -------------------------------------------------- |
+| `type`                    | Optional    | String   | Can only be `pushbullet` if specified              |
+| `pushbullet_token`        | Optional    | String   | Token for user. Can be specified via `${ENV_VAR}`. |
+| `pushbullet_proxy_type`   | Optional    | String   | HTTP proxy type, e.g. `https`                      |
+| `pushbullet_proxy_server` | Optional    | String   | HTTP proxy server URL                              |
 
-1. If `pushbullet_token` is specified in the format of `${ENVRION_VAR}` (e.g. `${PUSHBULLET_TOKEN}`), `ai_marketplace_monitor` will try to load the value from the specified environment variable.
-2. Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
+Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
 
 ### Email notification
 
-| Option          | Requirement | DataType    | Description                                             |
-| --------------- | ----------- | ----------- | ------------------------------------------------------- |
-| `type`          | Optional    | String      | Can only be `email` if specified                        |
-| `email`         | Optional    | String/List | One or more email addresses for email notifications     |
-| `smtp_username` | Optional    | String      | SMTP username.                                          |
-| `smtp_password` | Required    | String      | A password or passcode for the SMTP server.             |
-| `smtp_server`   | Optional    | String      | SMTP server, usually guessed from sender email address. |
-| `smtp_port`     | Optional    | Integer     | SMTP port, default to `587`                             |
+| Option          | Requirement | DataType    | Description                                                                    |
+| --------------- | ----------- | ----------- | ------------------------------------------------------------------------------ |
+| `type`          | Optional    | String      | Can only be `email` if specified                                               |
+| `email`         | Optional    | String/List | One or more email addresses for email notifications                            |
+| `smtp_username` | Optional    | String      | SMTP username. Can be specified via `${ENV_VAR}`.                              |
+| `smtp_password` | Required    | String      | A password or passcode for the SMTP server. Can be specified via `${ENV_VAR}`. |
+| `smtp_server`   | Optional    | String      | SMTP server, usually guessed from sender email address.                        |
+| `smtp_port`     | Optional    | Integer     | SMTP port, default to `587`                                                    |
 
 Note that
 
 1. We provide default `smtp_server` and `smtp_port` values for popular SMTP service providers.
 2. `smtp_username` is assumed to be the first `email`.
-3. If `smtp_password` is specified in the format of `${ENVRION_VAR}` (e.g. `${GMAIL_SMTP_PASSWORD}`), `ai_marketplace_monitor` will try to load the value from the specified environment variable.
 
 See [Setting up email notification](../README.md#setting-up-email-notification) for details on how to set up email notification.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,28 @@ Note that:
 
 1. Under the hood, _AI Marketplace Monitor_ merges all notification options into the user section. This allows you to share partial settings across users (e.g. `smtp_password`) while customizing specific details (e.g. `email`).
 2. If `notify_with` is not specified, the system will automatically include all notification settings for the user, so the `notify_with` option for `user.me` could be ignored.
+3. AI Marketplace Monitor does not support multiple notifications of the same type for a single user. For example, the following configuration is not supported:
+
+```toml
+[user.me]
+notify_with = ['pushbullet1', 'pushbullet2']
+```
+
+If you need to send notifications through multiple instances of the same type (e.g., multiple Pushbullet tokens), you must create separate users for each instance. For example:
+
+```toml
+[user.me]
+notify_with = ['pushbullet1']
+
+[user.other]
+notify_with = ['pushbullet2']
+
+[notification.pushbullet1]
+pushbullet_token = "xxxxxxxxxxxxxxxx"
+
+[notification.pushbullet2]
+pushbullet_token = "yyyyyyyyyyyyyyyy"
+```
 
 #### Pushbullet notification
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,33 +61,106 @@ Multiple marketplaces with different `name`s can be specified for different `ite
 
 ### Users
 
-One or more `user.username` sections are allowed. The `username` need to match what are listed by option `notify` of marketplace or items. Currently emails and [PushBullet](https://www.pushbullet.com/) are supported methods of notification.
+One or more `user.username` sections are allowed. The `username` need to match what are listed by option `notify` of marketplace or items. The `user` settings accept the following options
 
-| Option             | Requirement | DataType    | Description                                                                               |
-| ------------------ | ----------- | ----------- | ----------------------------------------------------------------------------------------- |
-| `pushbullet_token` | Optional    | String      | Token for user                                                                            |
-| `email`            | Optional    | String/List | One or more email addresses for email notificaitons                                       |
-| `remind`           | Optional    | String      | Notify users again after a set time (e.g., 3 days) if a listing remains active.           |
-| `smtp`             | optional    | String      | name of `SMTP` server to a separate SMTP section if there are more than one such sections |
-
-Option `remind` defines if a user want to receive repeated notification. By default users will be notified only once.
-
-### Notification
-
-If an `email` is specified, we need to know how to connect to an SMTP server to send the email. An smtp section should be named like `smtp.gmail` and can have the following keys
-
-| Option          | Requirement | DataType | Description                                             |
-| --------------- | ----------- | -------- | ------------------------------------------------------- |
-| `smtp_username` | Optional    | String   | SMTP username.                                          |
-| `smtp_password` | Required    | String   | A password or passcode for the SMTP server.             |
-| `smtp_server`   | Optional    | String   | SMTP server, usually guessed from sender email address. |
-| `smtp_port`     | Optional    | Integer  | SMTP port, default to `587`                             |
+| Option        | Requirement | DataType    | Description                                                                     |
+| ------------- | ----------- | ----------- | ------------------------------------------------------------------------------- |
+| `notify_with` | Optional    | String/List | name of one or more notification sections for notification                      |
+| `remind`      | Optional    | String      | Notify users again after a set time (e.g., 3 days) if a listing remains active. |
 
 Note that
 
-1. You can add values of an `smtp` section directly into a `user` section, or keep them an separate section to be shared by multiple users.
-2. We provide default `smtp_server` and `smtp_port` values for popular SMTP service providers.
-3. `smtp_username` is assumed to be the first `email`.
+1. Option `remind` defines if a user want to receive repeated notification. By default users will be notified only once.
+2. Settings for `notify_with` can be specified directly under the `user` setting, so any settings described in the following [Notification](#notification) section can be added to settings of a `user`.
+
+### Notification
+
+_AI Marketplace Monitor_ supports a number of notification methods. You can add settings for these methods directly to the `user` sections, or specify details of each notification methods in their own sections and use `user.notify_with` to point to one or more notification methods. The notification sections need to be named `notification.NAME`.
+
+For example, you can either use
+
+```toml
+[user.me]
+pushbullet_token = "xxxxxxxxxxxxxxxx"
+email = 'myemail@gmail.com'
+smtp_password = 'abcdefghijklmnop'
+```
+
+or
+
+```toml
+[user.me]
+notify_with = ['gmail', 'pushbullet']
+
+[notification.gmail]
+email = 'myemail@gmail.com'
+smtp_password = 'abcdefghijklmnop'
+
+[notification.pushbullet]
+pushbullet_token = "xxxxxxxxxxxxxxxx"
+```
+
+The former is preferred for a single user, and the latter is preferred for sharing settings among multiple users. Under the hood, `AI Marketplace Monitor` simply merges all notification options to the `user` section so it is possible for you to share only part of the settings. For example
+
+```toml
+[user.me]
+email = 'email1@gmail.com'
+notify_by = 'gmail'
+
+[user.other]
+email = ['email2@gmail.com', 'email3@gmail.com']
+notify_by = 'gmail'
+
+[notification.gmail]
+smtp_password = 'abcdefghijklmnop'
+```
+
+will send emails to different email addresses using the same `smtp` settings provided by `notification.gmail`.
+
+#### Pushbullet notification
+
+| Option                    | Requirement | DataType | Description                           |
+| ------------------------- | ----------- | -------- | ------------------------------------- |
+| `type`                    | Optional    | String   | Can only be `pushbullet` if specified |
+| `pushbullet_token`        | Optional    | String   | Token for user                        |
+| `pushbullet_proxy_type`   | Optional    | String   | HTTP proxy type, e.g. `https`         |
+| `pushbullet_proxy_server` | Optional    | String   | HTTP proxy server URL                 |
+
+Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
+
+#### Pushover notification
+
+| Option               | Requirement | DataType | Description                         |
+| -------------------- | ----------- | -------- | ----------------------------------- |
+| `type`               | Optional    | String   | Can only be `pushover` if specified |
+| `pushover_user_id`   | Optional    | String   | Token for user                      |
+| `pushover_api_token` | Optional    | String   | Token for user                      |
+
+The values of these values can be left blank, e.g.
+
+```toml
+[pushover.me]
+pushover_user_id = ''
+pushover_api_token = ''
+```
+
+in which case, `ai_marketplace_monitor` will try to load the values from environment variables `PUSHOVER_USER_ID` and `PUSHOVER_API_TOKEN` respectively.
+
+### Email notification
+
+| Option          | Requirement | DataType    | Description                                             |
+| --------------- | ----------- | ----------- | ------------------------------------------------------- |
+| `type`          | Optional    | String      | Can only be `email` if specified                        |
+| `email`         | Optional    | String/List | One or more email addresses for email notifications     |
+| `smtp_username` | Optional    | String      | SMTP username.                                          |
+| `smtp_password` | Required    | String      | A password or passcode for the SMTP server.             |
+| `smtp_server`   | Optional    | String      | SMTP server, usually guessed from sender email address. |
+| `smtp_port`     | Optional    | Integer     | SMTP port, default to `587`                             |
+
+Note that
+
+1. We provide default `smtp_server` and `smtp_port` values for popular SMTP service providers.
+2. `smtp_username` is assumed to be the first `email`.
 
 See [Setting up email notification](../README.md#setting-up-email-notification) for details on how to set up email notification.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,24 +148,6 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 1. If `pushbullet_token` is specified in the format of `${ENVRION_VAR}` (e.g. `${PUSHBULLET_TOKEN}`), `ai_marketplace_monitor` will try to load the value from the specified environment variable.
 2. Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
 
-#### Pushover notification
-
-| Option               | Requirement | DataType | Description                         |
-| -------------------- | ----------- | -------- | ----------------------------------- |
-| `type`               | Optional    | String   | Can only be `pushover` if specified |
-| `pushover_user_id`   | Optional    | String   | Token for user                      |
-| `pushover_api_token` | Optional    | String   | Token for user                      |
-
-The values of these values can be left blank, e.g.
-
-```toml
-[pushover.me]
-pushover_user_id = ''
-pushover_api_token = ''
-```
-
-in which case, `ai_marketplace_monitor` will try to load the values from environment variables `PUSHOVER_USER_ID` and `PUSHOVER_API_TOKEN` respectively.
-
 ### Email notification
 
 | Option          | Requirement | DataType    | Description                                             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,10 +124,10 @@ If you need to send notifications through multiple instances of the same type (e
 
 ```toml
 [user.me]
-notify_with = ['pushbullet1']
+notify_with = 'pushbullet1'
 
 [user.other]
-notify_with = ['pushbullet2']
+notify_with = 'pushbullet2'
 
 [notification.pushbullet1]
 pushbullet_token = "xxxxxxxxxxxxxxxx"
@@ -145,7 +145,8 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 | `pushbullet_proxy_type`   | Optional    | String   | HTTP proxy type, e.g. `https`         |
 | `pushbullet_proxy_server` | Optional    | String   | HTTP proxy server URL                 |
 
-Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
+1. If `pushbullet_token` is specified in the format of `${ENVRION_VAR}` (e.g. `${PUSHBULLET_TOKEN}`), `ai_marketplace_monitor` will try to load the value from the specified environment variable.
+2. Please refer to [PushBullet documentation](https://github.com/richard-better/pushbullet.py/blob/master/readme-old.md) for details on the use of a proxy server for pushbullet.
 
 #### Pushover notification
 
@@ -180,6 +181,7 @@ Note that
 
 1. We provide default `smtp_server` and `smtp_port` values for popular SMTP service providers.
 2. `smtp_username` is assumed to be the first `email`.
+3. If `smtp_password` is specified in the format of `${ENVRION_VAR}` (e.g. `${GMAIL_SMTP_PASSWORD}`), `ai_marketplace_monitor` will try to load the value from the specified environment variable.
 
 See [Setting up email notification](../README.md#setting-up-email-notification) for details on how to set up email notification.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,23 +61,26 @@ Multiple marketplaces with different `name`s can be specified for different `ite
 
 ### Users
 
-One or more `user.username` sections are allowed. The `username` need to match what are listed by option `notify` of marketplace or items. The `user` settings accept the following options
+One or more `user.username` sections can be defined in the configuration. The `username` one of the usernames listed in the `notify` option of `marketplace` or `item`. Each `user` section accepts the following options
 
-| Option        | Requirement | DataType    | Description                                                                     |
-| ------------- | ----------- | ----------- | ------------------------------------------------------------------------------- |
-| `notify_with` | Optional    | String/List | name of one or more notification sections for notification                      |
-| `remind`      | Optional    | String      | Notify users again after a set time (e.g., 3 days) if a listing remains active. |
+| Option        | Requirement | DataType    | Description                                                                                                                                                  |
+| ------------- | ----------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `notify_with` | Optional    | String/List | Specifies one or more notification methods to be used for this user. If left unspecified, all available notification methods will be used.                   |
+| `remind`      | Optional    | String      | Enables repeated notifications for the user after a specified duration (e.g., 3 days) if a listing remains active. By default, users are notified only once. |
 
 Note that
 
-1. Option `remind` defines if a user want to receive repeated notification. By default users will be notified only once.
-2. Settings for `notify_with` can be specified directly under the `user` setting, so any settings described in the following [Notification](#notification) section can be added to settings of a `user`.
+1. **Default Notification Behavior**: If the `notify_with` option is not specified, the system will use all available notification methods for the user.
+2. **Inline Notification Settings**: Notification settings can be defined directly under the user section. Any settings described in the [Notification](#notification) section can be applied to a user's configuration.
+3. **Repeated Notifications**: The `remind` option allows users to receive repeated notifications after a specified time interval. If not set, users will only be notified once about a listing.
 
 ### Notification
 
-_AI Marketplace Monitor_ supports a number of notification methods. You can add settings for these methods directly to the `user` sections, or specify details of each notification methods in their own sections and use `user.notify_with` to point to one or more notification methods. The notification sections need to be named `notification.NAME`.
+_AI Marketplace Monitor_ supports various notification methods, allowing you to configure notifications in a flexible way. You can define notification settings directly within the `user` sections or create dedicated `notification.NAME` sections and reference them using the `notify_with` option. This provides flexibility for single-user setups or shared configurations across multiple users.
 
-For example, you can either use
+#### Direct Notification Settings in User Sections
+
+Define notification details directly within the user section. This approach is ideal for single-user configurations.
 
 ```toml
 [user.me]
@@ -86,36 +89,30 @@ email = 'myemail@gmail.com'
 smtp_password = 'abcdefghijklmnop'
 ```
 
-or
+#### Shared Notification Settings in Dedicated Sections
+
+Define notification methods in their own `notification.NAME` sections and reference them using the notify_with option. This approach is better for sharing settings across multiple users.
 
 ```toml
 [user.me]
+email = 'myemail@gmail.com'
 notify_with = ['gmail', 'pushbullet']
 
+[user.other]
+email = 'other.email@gmail.com'
+notify_with = ['gmail']
+
 [notification.gmail]
-email = 'myemail@gmail.com'
 smtp_password = 'abcdefghijklmnop'
 
 [notification.pushbullet]
 pushbullet_token = "xxxxxxxxxxxxxxxx"
 ```
 
-The former is preferred for a single user, and the latter is preferred for sharing settings among multiple users. Under the hood, `AI Marketplace Monitor` simply merges all notification options to the `user` section so it is possible for you to share only part of the settings. For example
+Note that:
 
-```toml
-[user.me]
-email = 'email1@gmail.com'
-notify_by = 'gmail'
-
-[user.other]
-email = ['email2@gmail.com', 'email3@gmail.com']
-notify_by = 'gmail'
-
-[notification.gmail]
-smtp_password = 'abcdefghijklmnop'
-```
-
-will send emails to different email addresses using the same `smtp` settings provided by `notification.gmail`.
+1. Under the hood, _AI Marketplace Monitor_ merges all notification options into the user section. This allows you to share partial settings across users (e.g. `smtp_password`) while customizing specific details (e.g. `email`).
+2. If `notify_with` is not specified, the system will automatically include all notification settings for the user, so the `notify_with` option for `user.me` could be ignored.
 
 #### Pushbullet notification
 

--- a/src/ai_marketplace_monitor/config.py
+++ b/src/ai_marketplace_monitor/config.py
@@ -190,23 +190,23 @@ class Config(Generic[TAIConfig, TItemConfig, TMarketplaceConfig]):
                     )
 
     def expand_notifications(self: "Config") -> None:
-
         for config in self.user.values():
-            if config.notify_with:
-                for notification_name in config.notify_with:
-                    if notification_name not in self.notification:
-                        raise ValueError(
-                            f"User {hilight(config.name)} specifies an undefined notification method {notification_name}."
-                        )
-                    notification_config = self.notification[notification_name]
-                    #
-                    if notification_config.enabled is False:
-                        continue
-                    # add values of smtp_config to user config
-                    for key, value in notification_config.__dict__.items():
-                        # name is the notification name and should not override username
-                        if key not in ("type", "name"):
-                            setattr(config, key, value)
+            for notification_name in (
+                config.notify_with if config.notify_with is not None else self.notification.keys()
+            ):
+                if notification_name not in self.notification:
+                    raise ValueError(
+                        f"User {hilight(config.name)} specifies an undefined notification method {notification_name}."
+                    )
+                notification_config = self.notification[notification_name]
+                #
+                if notification_config.enabled is False:
+                    continue
+                # add values of smtp_config to user config
+                for key, value in notification_config.__dict__.items():
+                    # name is the notification name and should not override username
+                    if key not in ("type", "name"):
+                        setattr(config, key, value)
 
     def expand_regions(self: "Config") -> None:
         # if region is specified in other section, they must exist

--- a/src/ai_marketplace_monitor/email_notify.py
+++ b/src/ai_marketplace_monitor/email_notify.py
@@ -15,7 +15,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from .ai import AIResponse  # type: ignore
 from .listing import Listing
 from .notification import NotificationConfig, NotificationStatus
-from .utils import fetch_with_retry, hilight, resize_image_data
+from .utils import fetch_with_retry, hilight, resize_image_data, value_from_environ
 
 
 @dataclass
@@ -42,6 +42,7 @@ class EmailNotificationConfig(NotificationConfig):
     def handle_smtp_server(self: "EmailNotificationConfig") -> None:
         if self.smtp_server is None:
             return
+
         if not isinstance(self.smtp_server, str):
             raise ValueError("user requires a string smtp_server.")
         self.smtp_server = self.smtp_server.strip()
@@ -66,9 +67,14 @@ class EmailNotificationConfig(NotificationConfig):
     def handle_smtp_password(self: "EmailNotificationConfig") -> None:
         if self.smtp_password is None:
             return
+
+        self.smtp_password = value_from_environ(self.smtp_password)
+
         # smtp_password should be a string
-        if not isinstance(self.smtp_password, str):
-            raise ValueError("user requires a string smtp_password.")
+        if not isinstance(self.smtp_password, str) or not self.smtp_password:
+            raise ValueError(
+                "A non-empty value or environment variable SMTP_PASSWORD is needed for option smtp_password."
+            )
         self.smtp_password = self.smtp_password.strip()
 
     def handle_smtp_from(self: "EmailNotificationConfig") -> None:

--- a/src/ai_marketplace_monitor/email_notify.py
+++ b/src/ai_marketplace_monitor/email_notify.py
@@ -14,25 +14,39 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .ai import AIResponse  # type: ignore
 from .listing import Listing
-from .utils import BaseConfig, NotificationStatus, fetch_with_retry, hilight, resize_image_data
+from .notification import NotificationConfig, NotificationStatus
+from .utils import fetch_with_retry, hilight, resize_image_data
 
 
 @dataclass
-class SMTPConfig(BaseConfig):
+class EmailNotificationConfig(NotificationConfig):
+    email: List[str] | None = None
     smtp_server: str | None = None
     smtp_port: int | None = None
     smtp_username: str | None = None
     smtp_password: str | None = None
     smtp_from: str | None = None
 
-    def handle_smtp_server(self: "SMTPConfig") -> None:
+    def handle_email(self: "EmailNotificationConfig") -> None:
+        if self.email is None:
+            return
+        if isinstance(self.email, str):
+            self.email = [self.email]
+        if not isinstance(self.email, list) or not all(
+            (isinstance(x, str) and "@" in x and "." in x.split("@")[1]) for x in self.email
+        ):
+            raise ValueError(
+                f"Item {hilight(self.name)} email must be a string or list of string."
+            )
+
+    def handle_smtp_server(self: "EmailNotificationConfig") -> None:
         if self.smtp_server is None:
             return
         if not isinstance(self.smtp_server, str):
             raise ValueError("user requires a string smtp_server.")
         self.smtp_server = self.smtp_server.strip()
 
-    def handle_smtp_port(self: "SMTPConfig") -> None:
+    def handle_smtp_port(self: "EmailNotificationConfig") -> None:
         if self.smtp_port is None:
             return
 
@@ -41,7 +55,7 @@ class SMTPConfig(BaseConfig):
         if self.smtp_port < 1 or self.smtp_port > 65535:
             raise ValueError("user requires an integer smtp_port between 1 and 65535.")
 
-    def handle_smtp_username(self: "SMTPConfig") -> None:
+    def handle_smtp_username(self: "EmailNotificationConfig") -> None:
         if self.smtp_username is None:
             return
         # smtp_username should be a string
@@ -49,7 +63,7 @@ class SMTPConfig(BaseConfig):
             raise ValueError("user requires a string smtp_username.")
         self.smtp_username = self.smtp_username.strip()
 
-    def handle_smtp_password(self: "SMTPConfig") -> None:
+    def handle_smtp_password(self: "EmailNotificationConfig") -> None:
         if self.smtp_password is None:
             return
         # smtp_password should be a string
@@ -57,7 +71,7 @@ class SMTPConfig(BaseConfig):
             raise ValueError("user requires a string smtp_password.")
         self.smtp_password = self.smtp_password.strip()
 
-    def handle_smtp_from(self: "SMTPConfig") -> None:
+    def handle_smtp_from(self: "EmailNotificationConfig") -> None:
         if self.smtp_from is None:
             return
         # smtp_from should be a string
@@ -66,7 +80,7 @@ class SMTPConfig(BaseConfig):
         self.smtp_from = self.smtp_from.strip()
 
     def get_title(
-        self: "SMTPConfig",
+        self: "EmailNotificationConfig",
         listings: List[Listing],
         notification_status: List[NotificationStatus],
         force: bool = False,
@@ -97,7 +111,7 @@ class SMTPConfig(BaseConfig):
         return title
 
     def get_text_message(
-        self: "SMTPConfig",
+        self: "EmailNotificationConfig",
         listings: List[Listing],
         ratings: List[AIResponse],
         notification_status: List[NotificationStatus],
@@ -134,7 +148,7 @@ class SMTPConfig(BaseConfig):
         return message
 
     def get_html_message(
-        self: "SMTPConfig",
+        self: "EmailNotificationConfig",
         listings: List[Listing],
         ratings: List[AIResponse],
         notification_status: List[NotificationStatus],
@@ -187,15 +201,14 @@ class SMTPConfig(BaseConfig):
         return html, images
 
     def notify_through_email(
-        self: "SMTPConfig",
-        recipients: List[str] | None,
+        self: "EmailNotificationConfig",
         listings: List[Listing],
         ratings: List[AIResponse],
         notification_status: List[NotificationStatus],
         force: bool = False,
         logger: Logger | None = None,
     ) -> bool:
-        if not recipients:
+        if not self.email:
             if logger:
                 logger.debug("No recipients specified. No email sent.")
             return False
@@ -211,25 +224,22 @@ class SMTPConfig(BaseConfig):
         html_message, images = self.get_html_message(
             listings, ratings, notification_status, force, logger=logger
         )
-        return self.send_email_message(
-            recipients, title, message, html_message, images, logger=logger
-        )
+        return self.send_email_message(title, message, html_message, images, logger=logger)
 
     def send_email_message(
-        self: "SMTPConfig",
-        recipients: List[str] | None,
+        self: "EmailNotificationConfig",
         title: str,
         message: str,
         html: str,
         images: List[Tuple[bytes, str, str]],
         logger: Logger | None = None,
     ) -> bool:
-        if not recipients:
+        if not self.email:
             if logger:
                 logger.debug("No recipients specified. No email sent.")
             return False
 
-        sender = self.smtp_from or self.smtp_username or recipients[0]
+        sender = self.smtp_from or self.smtp_username or self.email[0]
 
         if self.smtp_server:
             smtp_server = self.smtp_server
@@ -241,7 +251,7 @@ class SMTPConfig(BaseConfig):
         msg["Subject"] = title
         # can use the humanized version of self.name as well
         msg["From"] = formataddr(("AI Marketplace Monitor", sender))
-        msg["To"] = ", ".join(recipients)
+        msg["To"] = ", ".join(self.email)
 
         # Create alternative part
         alt_part = MIMEMultipart("alternative")

--- a/src/ai_marketplace_monitor/email_notify.py
+++ b/src/ai_marketplace_monitor/email_notify.py
@@ -59,9 +59,12 @@ class EmailNotificationConfig(NotificationConfig):
     def handle_smtp_username(self: "EmailNotificationConfig") -> None:
         if self.smtp_username is None:
             return
+
+        self.smtp_username = value_from_environ(self.smtp_username)
+
         # smtp_username should be a string
-        if not isinstance(self.smtp_username, str):
-            raise ValueError("user requires a string smtp_username.")
+        if not isinstance(self.smtp_username, str) or not self.smtp_username:
+            raise ValueError("A non-empty value is requires for option smtp_username.")
         self.smtp_username = self.smtp_username.strip()
 
     def handle_smtp_password(self: "EmailNotificationConfig") -> None:
@@ -72,9 +75,7 @@ class EmailNotificationConfig(NotificationConfig):
 
         # smtp_password should be a string
         if not isinstance(self.smtp_password, str) or not self.smtp_password:
-            raise ValueError(
-                "A non-empty value or environment variable SMTP_PASSWORD is needed for option smtp_password."
-            )
+            raise ValueError("A non-empty value is is required for option smtp_password.")
         self.smtp_password = self.smtp_password.strip()
 
     def handle_smtp_from(self: "EmailNotificationConfig") -> None:

--- a/src/ai_marketplace_monitor/facebook.py
+++ b/src/ai_marketplace_monitor/facebook.py
@@ -24,6 +24,7 @@ from .utils import (
     extract_price,
     hilight,
     is_substring,
+    value_from_environ,
 )
 
 
@@ -174,12 +175,18 @@ class FacebookMarketplaceConfig(MarketplaceConfig, FacebookMarketItemCommonConfi
     def handle_username(self: "FacebookMarketplaceConfig") -> None:
         if self.username is None:
             return
+
+        self.username = value_from_environ(self.username)
+
         if not isinstance(self.username, str):
             raise ValueError(f"Marketplace {self.name} username must be a string.")
 
     def handle_password(self: "FacebookMarketplaceConfig") -> None:
         if self.password is None:
             return
+
+        self.password = value_from_environ(self.password)
+
         if not isinstance(self.password, str):
             raise ValueError(f"Marketplace {self.name} password must be a string.")
 

--- a/src/ai_marketplace_monitor/monitor.py
+++ b/src/ai_marketplace_monitor/monitor.py
@@ -16,11 +16,11 @@ from .ai import AIBackend, AIResponse
 from .config import Config, supported_ai_backends, supported_marketplaces
 from .listing import Listing
 from .marketplace import Marketplace, TItemConfig, TMarketplaceConfig
+from .notification import NotificationStatus
 from .user import User
 from .utils import (
     CounterItem,
     KeyboardMonitor,
-    NotificationStatus,
     SleepStatus,
     amm_home,
     cache,

--- a/src/ai_marketplace_monitor/notification.py
+++ b/src/ai_marketplace_monitor/notification.py
@@ -15,7 +15,6 @@ class NotificationStatus(Enum):
 class NotificationType(Enum):
     EMAIL = "email"
     PUSHBULLET = "pushbullet"
-    pushover = "pushover"
 
 
 @dataclass

--- a/src/ai_marketplace_monitor/notification.py
+++ b/src/ai_marketplace_monitor/notification.py
@@ -48,5 +48,7 @@ class NotificationConfig(BaseConfig):
                     raise ValueError("Invalid notification config for type {subclass_name}")
                 return subclass(**kwargs)
             if all(name in acceptable_keys for name in kwargs.keys()):
-                return subclass(**kwargs)
+                return subclass(
+                    type=subclass_name, **{k: v for k, v in kwargs.items() if k != "type"}
+                )
         raise ValueError("Invalid notification config")

--- a/src/ai_marketplace_monitor/notification.py
+++ b/src/ai_marketplace_monitor/notification.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, fields
+from enum import Enum
+from typing import Any, Type
+
+from .utils import BaseConfig
+
+
+class NotificationStatus(Enum):
+    NOT_NOTIFIED = 0
+    EXPIRED = 1
+    NOTIFIED = 2
+    LISTING_CHANGED = 3
+
+
+class NotificationType(Enum):
+    EMAIL = "email"
+    PUSHBULLET = "pushbullet"
+    pushover = "pushover"
+
+
+@dataclass
+class NotificationConfig(BaseConfig):
+    type: str | None = None
+
+    def handle_type(self: "NotificationConfig") -> None:
+        """Handle the type of the notification"""
+        if self.type is None:
+            return None
+        # if specified, it should be one of the values from NotificationType
+        if self.type not in [notification_type.value for notification_type in NotificationType]:
+            raise ValueError("Invalid notification type")
+
+    @classmethod
+    def get_config(cls: Type["NotificationConfig"], **kwargs: Any) -> "NotificationConfig":
+        """Get the specific subclass name from the specified keys, for validation purposes"""
+        from .email_notify import EmailNotificationConfig
+        from .pushbullet import PushbulletNotificationConfig
+
+        acceptable_notification_classes = {
+            NotificationType.EMAIL.value: EmailNotificationConfig,
+            NotificationType.PUSHBULLET.value: PushbulletNotificationConfig,
+        }
+
+        for subclass_name, subclass in acceptable_notification_classes.items():
+            acceptable_keys = {field.name for field in fields(subclass)}
+            if subclass_name == kwargs.get("type", None):
+                if not all(name in kwargs.keys() for name in acceptable_keys):
+                    raise ValueError("Invalid notification config for type {subclass_name}")
+                return subclass(**kwargs)
+            if all(name in acceptable_keys for name in kwargs.keys()):
+                return subclass(**kwargs)
+        raise ValueError("Invalid notification config")

--- a/src/ai_marketplace_monitor/pushbullet.py
+++ b/src/ai_marketplace_monitor/pushbullet.py
@@ -10,7 +10,7 @@ from pushbullet import Pushbullet  # type: ignore
 from .ai import AIResponse  # type: ignore
 from .listing import Listing
 from .notification import NotificationConfig, NotificationStatus
-from .utils import hilight
+from .utils import hilight, value_from_environ
 
 
 @dataclass
@@ -22,8 +22,13 @@ class PushbulletNotificationConfig(NotificationConfig):
     def handle_pushbullet_token(self: "PushbulletNotificationConfig") -> None:
         if self.pushbullet_token is None:
             return
+
+        self.pushbullet_token = value_from_environ(self.pushbullet_token)
+
         if not isinstance(self.pushbullet_token, str) or not self.pushbullet_token:
-            raise ValueError("user requires an non-empty pushbullet_token.")
+            raise ValueError(
+                "An non-empty pushbullet_token should be specified in config file or through ab environment variable PUSHBULLET_TOKEN."
+            )
         self.pushbullet_token = self.pushbullet_token.strip()
 
     def handle_pushbullet_proxy_type(self: "PushbulletNotificationConfig") -> None:

--- a/src/ai_marketplace_monitor/pushbullet.py
+++ b/src/ai_marketplace_monitor/pushbullet.py
@@ -9,19 +9,50 @@ from pushbullet import Pushbullet  # type: ignore
 
 from .ai import AIResponse  # type: ignore
 from .listing import Listing
-from .utils import (
-    BaseConfig,
-    NotificationStatus,
-    hilight,
-)
+from .notification import NotificationConfig, NotificationStatus
+from .utils import hilight
 
 
 @dataclass
-class PushbulletConfig(BaseConfig):
+class PushbulletNotificationConfig(NotificationConfig):
     pushbullet_token: str | None = None
+    pushbullet_proxy_type: str | None = None
+    pushbullet_proxy_server: str | None = None
+
+    def handle_pushbullet_token(self: "PushbulletNotificationConfig") -> None:
+        if self.pushbullet_token is None:
+            return
+        if not isinstance(self.pushbullet_token, str) or not self.pushbullet_token:
+            raise ValueError("user requires an non-empty pushbullet_token.")
+        self.pushbullet_token = self.pushbullet_token.strip()
+
+    def handle_pushbullet_proxy_type(self: "PushbulletNotificationConfig") -> None:
+        if self.pushbullet_proxy_type is None:
+            return
+        if not isinstance(self.pushbullet_proxy_type, str) or not self.pushbullet_proxy_type:
+            raise ValueError("user requires an non-empty pushbullet_proxy_type.")
+        self.pushbullet_proxy_type = self.pushbullet_proxy_type.strip()
+
+    def handle_pushbullet_proxy_server(self: "PushbulletNotificationConfig") -> None:
+        # pushbullet_proxy_server and pushbullet_proxy_type are both required to be set
+        # if either of them is set, then both of them must be set
+        if self.pushbullet_proxy_type is None and self.pushbullet_proxy_server is not None:
+            raise ValueError(
+                "user requires an non-empty pushbullet_proxy_type when pushbullet_proxy_server is set."
+            )
+        # if pushbullet_proxy_type is set, then pushbullet_proxy_server must be set
+        if self.pushbullet_proxy_type is not None and self.pushbullet_proxy_server is None:
+            raise ValueError(
+                "user requires an non-empty pushbullet_proxy_server when pushbullet_proxy_type is set."
+            )
+        if self.pushbullet_proxy_server is None:
+            return
+        if not isinstance(self.pushbullet_proxy_server, str) or not self.pushbullet_proxy_server:
+            raise ValueError("user requires an non-empty pushbullet_proxy_server.")
+        self.pushbullet_proxy_server = self.pushbullet_proxy_server.strip()
 
     def notify_through_pushbullet(
-        self: "PushbulletConfig",
+        self: "PushbulletNotificationConfig",
         listings: List[Listing],
         ratings: List[AIResponse],
         notification_status: List[NotificationStatus],
@@ -77,7 +108,7 @@ class PushbulletConfig(BaseConfig):
         return True
 
     def send_pushbullet_message(
-        self: "PushbulletConfig",
+        self: "PushbulletNotificationConfig",
         title: str,
         message: str,
         max_retries: int = 6,
@@ -89,7 +120,13 @@ class PushbulletConfig(BaseConfig):
                 logger.debug("No pushbullet_token specified.")
             return False
 
-        pb = Pushbullet(self.pushbullet_token)
+        if self.pushbullet_proxy_server and self.pushbullet_proxy_type:
+            pb = Pushbullet(
+                self.pushbullet_token,
+                proxy={self.pushbullet_proxy_type: self.pushbullet_proxy_server},
+            )
+        else:
+            pb = Pushbullet(self.pushbullet_token)
 
         for attempt in range(max_retries):
             try:

--- a/src/ai_marketplace_monitor/pushbullet.py
+++ b/src/ai_marketplace_monitor/pushbullet.py
@@ -26,9 +26,7 @@ class PushbulletNotificationConfig(NotificationConfig):
         self.pushbullet_token = value_from_environ(self.pushbullet_token)
 
         if not isinstance(self.pushbullet_token, str) or not self.pushbullet_token:
-            raise ValueError(
-                "An non-empty pushbullet_token should be specified in config file or through ab environment variable PUSHBULLET_TOKEN."
-            )
+            raise ValueError("An non-empty pushbullet_token is needed.")
         self.pushbullet_token = self.pushbullet_token.strip()
 
     def handle_pushbullet_proxy_type(self: "PushbulletNotificationConfig") -> None:

--- a/src/ai_marketplace_monitor/utils.py
+++ b/src/ai_marketplace_monitor/utils.py
@@ -525,4 +525,6 @@ def value_from_environ(key: str) -> str:
     """Replace key with value from an environment variable if it has a format of ${KEY}"""
     if not isinstance(key, str) or not key.startswith("${") or not key.endswith("}"):
         return key
-    return os.environ.get(key[2:-1], key)
+    if key[2:-1] not in os.environ:
+        raise ValueError(f"Environment variable {key[2:-1]} not set")
+    return os.environ[key[2:-1]]

--- a/src/ai_marketplace_monitor/utils.py
+++ b/src/ai_marketplace_monitor/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import re
 import time
 from dataclasses import asdict, dataclass, fields
@@ -54,13 +55,6 @@ class SleepStatus(Enum):
     NOT_DISRUPTED = 0
     BY_KEYBOARD = 1
     BY_FILE_CHANGE = 2
-
-
-class NotificationStatus(Enum):
-    NOT_NOTIFIED = 0
-    EXPIRED = 1
-    NOTIFIED = 2
-    LISTING_CHANGED = 3
 
 
 class CacheType(Enum):
@@ -525,3 +519,10 @@ def resize_image_data(image_data: bytes, max_width: int = 800, max_height: int =
     buffer = io.BytesIO()
     resized_image.save(buffer, format=image.format)
     return buffer.getvalue()
+
+
+def value_from_environ(key: str) -> str:
+    """Replace key with value from an environment variable if it has a format of ${KEY}"""
+    if not isinstance(key, str) or not key.startswith("${") or not key.endswith("}"):
+        return key
+    return os.environ.get(key[2:-1], key)

--- a/tests/test_ai_marketplace_monitor.py
+++ b/tests/test_ai_marketplace_monitor.py
@@ -5,8 +5,8 @@ import time
 from diskcache import Cache  # type: ignore
 
 from ai_marketplace_monitor.listing import Listing
+from ai_marketplace_monitor.notification import NotificationStatus
 from ai_marketplace_monitor.user import User
-from ai_marketplace_monitor.utils import NotificationStatus
 
 
 def test_version(version: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,21 @@ api_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 model = 'gpt'
 """
 
+base_pushbullet_cfg = """
+[notification.pushbullet1]
+pushbullet_token = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+"""
+
+base_email_cfg = """
+[notification.gmail]
+smtp_password = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+"""
+
+notify_user_cfg = """
+[user.user1]
+notify_with = ['pushbullet1', 'gmail']
+"""
+
 
 @pytest.mark.parametrize(
     "config_content,acceptable",
@@ -140,6 +155,27 @@ model = 'gpt'
         (base_marketplace_cfg + base_item_cfg + base_user_cfg + base_ai_cfg, True),
         (full_marketplace_cfg + full_item_cfg + full_user_cfg + full_ai_cfg, True),
         (base_marketplace_cfg + full_item_cfg + base_user_cfg + base_ai_cfg, True),
+        # notification should match
+        (
+            base_marketplace_cfg + full_item_cfg + notify_user_cfg,
+            False,
+        ),
+        (
+            base_marketplace_cfg
+            + base_item_cfg
+            + notify_user_cfg
+            + base_pushbullet_cfg
+            + base_email_cfg,
+            True,
+        ),
+        (
+            base_marketplace_cfg
+            + base_item_cfg
+            + notify_user_cfg
+            + base_pushbullet_cfg.replace("pushbullet1", "somethingelse")
+            + base_email_cfg,
+            False,
+        ),
         # user should match
         (
             base_marketplace_cfg + full_item_cfg.replace("user1", "unknown_user") + base_user_cfg,


### PR DESCRIPTION
## Proposed Changes

- rename sections `smtp` to `notification`
- rename option `smtp` to `notify_with`
- Move `email` setting to `SMTPConfiguration`
- Add a super class for `SMTPConfiguraiton` and `PushbulletConfiguraiton`
- Support `proxy` for PushBullet
- Support using environment variables for password.