### PR TITLE
rotating vpn #157

### DIFF
--- a/src/ai_marketplace_monitor/config.py
+++ b/src/ai_marketplace_monitor/config.py
@@ -140,7 +140,7 @@ class Config(Generic[TAIConfig, TItemConfig, TMarketplaceConfig]):
                 )
             marketplace_class = supported_marketplaces[market_type]
             self.marketplace[marketplace_name] = marketplace_class.get_config(
-                name=marketplace_name, **marketplace_config
+                name=marketplace_name, monitor_config=self.monitor, **marketplace_config
             )
             lan = self.marketplace[marketplace_name].language
             if lan is None:

--- a/src/ai_marketplace_monitor/facebook.py
+++ b/src/ai_marketplace_monitor/facebook.py
@@ -275,8 +275,8 @@ class FacebookMarketplace(Marketplace):
 
     def login(self: "FacebookMarketplace") -> None:
         assert self.browser is not None
-        context = self.browser.new_context()
-        self.page = context.new_page()
+
+        self.page = self.create_page(swap_proxy=True)
 
         # Navigate to the URL, no timeout
         self.goto_url(self.initial_url)

--- a/src/ai_marketplace_monitor/monitor.py
+++ b/src/ai_marketplace_monitor/monitor.py
@@ -394,9 +394,7 @@ class MarketplaceMonitor:
         # Open a new browser page.
         self.load_config_file()
         assert self.config is not None
-        self.browser = self.playwright.chromium.launch(
-            headless=self.headless, proxy=self.config.monitor.get_proxy_options()
-        )
+        self.browser = self.playwright.chromium.launch(headless=self.headless)
         #
         assert self.browser is not None
         while True:
@@ -552,9 +550,7 @@ class MarketplaceMonitor:
                             self.logger.info(
                                 f"""{hilight("[Search]", "info")} Starting a browser because the item was not checked before."""
                             )
-                        self.browser = self.playwright.chromium.launch(
-                            headless=self.headless, proxy=self.config.monitor.get_proxy_options()
-                        )
+                        self.browser = self.playwright.chromium.launch(headless=self.headless)
                         marketplace.set_browser(self.browser)
 
                 # ignore enabled


### PR DESCRIPTION
Fixes #157

## Proposed Changes

  - Passing monitor config to marketplace config
  - add function create_page with option to swap_proxy
  - ??

The problem is that rotating page could force re-login into facebook and break existing workflow.
