### PR TITLE
Fix CLI test failures by adding missing monitor_config type validation

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,6 +279,7 @@ def test_config(config_file: Callable, config_content: str, acceptable: bool) ->
         "market_type": (str, type(None)),
         "min_price": (str, type(None)),
         "model": (str, type(None)),
+        "monitor_config": dict,
         "name": (str, type(None)),
         "notify": (list, type(None)),
         "password": (str, type(None)),


### PR DESCRIPTION
- Add monitor_config: dict to key_types dictionary in test_config function
- Resolves KeyError: 'monitor_config' that was causing 9 test failures
- All CLI config tests now pass (65 passed, 1 skipped)


