### PR TITLE
Add user agent identification headers

### DIFF
--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -255,6 +255,10 @@ class OpenAIBackend(AIBackend):
                 api_key=self.config.api_key,
                 base_url=self.config.base_url or self.base_url,
                 timeout=self.config.timeout,
+                default_headers={
+                    "X-Title": "AI Marketplace Monitor",
+                    "HTTP-Referer": "https://github.com/BoPeng/ai-marketplace-monitor",
+                },
             )
             if self.logger:
                 self.logger.info(f"""{hilight("[AI]", "name")} {self.config.name} connected.""")


### PR DESCRIPTION
Addresses GitHub issue #240 by adding proper application identification when using OpenRouter API. This ensures the application appears as "AI Marketplace Monitor" in OpenRouter's dashboard instead of "Unknown" and provides a direct link to the GitHub repository.

- Added X-Title header with application name
- Added HTTP-Referer header with repository URL
- Follows OpenRouter's recommended identification practices

Fixes #240 
