### PR TITLE
Fix minor docs inaccuracies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ One of more sections to list the AI agent that can be used to judge if listings 
 | Option        | Requirement | DataType | Description                                                |
 | ------------- | ----------- | -------- | ---------------------------------------------------------- |
 | `provider`    | Optional    | String   | Name of the AI service provider.                           |
-| `api-key`     | Optional    | String   | A program token to access the RESTful API.                 |
+| `api_key`     | Optional    | String   | A program token to access the RESTful API.                 |
 | `base_url`    | Optional    | String   | URL for the RESTful API                                    |
 | `model`       | Optional    | String   | Language model to be used.                                 |
 | `max_retries` | Optional    | Integer  | Max retry attempts if connection fails. Default to 10.     |
@@ -50,7 +50,7 @@ Note that:
    [DeepSeek](https://www.deepseek.com/), or [Ollama](https://ollama.com/). The name of the ai service will be used if this option is not specified so `OpenAI` will be used for section `ai.openai`.
 2. [OpenAI](https://openai.com/) and [DeepSeek](https://www.deepseek.com/) models sets default `base_url` and `model` for these providers.
 3. Ollama models require `base_url`. A default model is set to `deepseek-r1:14b`, which seems to be good enough for this application. You can of course try [other models](https://ollama.com/library) by setting the `model` option.
-4. Although only three providers are supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api-key`.
+4. Although only three providers are supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api_key`.
 5. You can use option `ai` to list the AI services for particular marketplaces or items.
 
 A typical section for OpenAI looks like

--- a/docs/configuration-guide.rst
+++ b/docs/configuration-guide.rst
@@ -89,8 +89,8 @@ By default, notifications include the **title**, **price**, **location**, **desc
 
 You can set `with_description` to:
 
-- `True` — to include the **full description**.
-- `False` — to exclude the description (default behavior).
+- `true` — to include the **full description**.
+- `false` — to exclude the description (default behavior).
 - A **number** — to include only the **first N characters** of the description.
 
 For example:


### PR DESCRIPTION
Some typos in the docs led to config parse failures:

`api_key` not `api-key`

True/False should be `true`/`false`.

That's it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the optional credential key from "api-key" to "api_key" throughout the configuration docs to match the supported format.
  * Standardized boolean examples for a description toggle to use lowercase true/false while preserving the described behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->