### PR TITLE
Add configurable rate limiting framework for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [issue 235](https://github.com/BoPeng/ai-marketplace-monitor/issues/235) Configurable rate limiting framework for all notification types
+  - Rate limiting infrastructure moved from Telegram-specific to base notification class
+  - Automatic rate limiting for Telegram with intelligent chat type detection (1.1s individual, 3.0s group)
+  - Configurable instance-level and global rate limiting for all notification methods
+  - Opt-in rate limiting for email, PushBullet, PushOver, and other notification types
+  - Comprehensive test coverage for rate limiting behavior
+
 ## [0.9.12]
 
 - [Issue 289](https://github.com/BoPeng/ai-marketplace-monitor/issues/289). Fix 30s timeout delay in get_seller for anonymous mode.

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,7 +168,7 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 Note that
 
 1. These settings are shared across all notification methods. For example, if you are notifying with `notify_with=['gmail', 'pushbullet']`, the same `max_retries` and `retry_delay` will apply to both methods.
-2. Support for `with_description` vary across notification methods due to their own limitations and strenght. For example, email notification will always include description.
+2. Support for `with_description` vary across notification methods due to their own limitations and strength. For example, email notification will always include description.
 3. Rate limiting prevents API violations by controlling message frequency. When enabled, the system waits for the longer of `instance_rate_limit` or `global_rate_limit` before sending each message. Telegram automatically enables rate limiting with optimized defaults for individual (1.1s) and group chats (3.0s).
 
 #### Telegram notification

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,16 +156,35 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 
 #### Common Notification settings
 
-| Option             | Requirement | DataType        | Description                                                                                                                      |
-| ------------------ | ----------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `max_retries`      | Optional    | Integer         | Number of attempts to retry a notification. Defaults to `5`.                                                                     |
-| `retry_delay`      | Optional    | Integer         | Time in seconds to wait between retry attempts. Defaults to `60`.                                                                |
-| `with_description` | Optional    | Boolean/Integer | Whether or not include description of listings. If a number is given, the description will be truncated to the specified length. |
+| Option                  | Requirement | DataType        | Description                                                                                                                      |
+| ----------------------- | ----------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `max_retries`           | Optional    | Integer         | Number of attempts to retry a notification. Defaults to `5`.                                                                     |
+| `retry_delay`           | Optional    | Integer         | Time in seconds to wait between retry attempts. Defaults to `60`.                                                                |
+| `with_description`      | Optional    | Boolean/Integer | Whether or not include description of listings. If a number is given, the description will be truncated to the specified length. |
+| `rate_limit_enabled`    | Optional    | Boolean         | Enable rate limiting for this notification method. Defaults to `false` (except Telegram which defaults to `true`).              |
+| `instance_rate_limit`   | Optional    | Integer         | Minimum seconds between messages for this specific configuration instance. Defaults to `1`.                                      |
+| `global_rate_limit`     | Optional    | Integer         | Minimum seconds between any messages globally across all instances. Defaults to `30`.                                           |
 
 Note that
 
 1. These settings are shared across all notification methods. For example, if you are notifying with `notify_with=['gmail', 'pushbullet']`, the same `max_retries` and `retry_delay` will apply to both methods.
 2. Support for `with_description` vary across notification methods due to their own limitations and strenght. For example, email notification will always include description.
+3. Rate limiting prevents API violations by controlling message frequency. When enabled, the system waits for the longer of `instance_rate_limit` or `global_rate_limit` before sending each message. Telegram automatically enables rate limiting with optimized defaults for individual (1.1s) and group chats (3.0s).
+
+#### Telegram notification
+
+| Option             | Requirement | DataType | Description                                    |
+| ------------------ | ----------- | -------- | ---------------------------------------------- |
+| `telegram_token`   | Required    | String   | Bot token obtained from @BotFather.           |
+| `telegram_chat_id` | Required    | String   | Chat ID for receiving notifications.           |
+
+Note that
+
+1. **Automatic Rate Limiting**: Telegram notifications automatically enable rate limiting (`rate_limit_enabled = true`) with intelligent defaults based on chat type.
+2. **Smart Chat Detection**: The system automatically detects individual chats (positive chat IDs) vs group chats (negative chat IDs) and applies appropriate rate limits.
+3. **Optimized Limits**: Individual chats use 1.1 seconds between messages, group chats use 3.0 seconds, with a global limit of 30 seconds across all Telegram instances.
+4. **HTTP 429 Handling**: Built-in retry logic with exponential backoff for Telegram API rate limit responses.
+5. **Message Splitting**: Long messages are automatically split while preserving MarkdownV2 formatting.
 
 #### Pushbullet notification
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,7 @@ pushbullet_token = "yyyyyyyyyyyyyyyy"
 | `with_description`      | Optional    | Boolean/Integer | Whether or not include description of listings. If a number is given, the description will be truncated to the specified length. |
 | `rate_limit_enabled`    | Optional    | Boolean         | Enable rate limiting for this notification method. Defaults to `false` (except Telegram which defaults to `true`).              |
 | `instance_rate_limit`   | Optional    | Integer         | Minimum seconds between messages for this specific configuration instance. Defaults to `1`.                                      |
-| `global_rate_limit`     | Optional    | Integer         | Minimum seconds between any messages globally across all instances. Defaults to `30`.                                           |
+| `global_rate_limit`     | Optional    | Integer         | Maximum messages per second across all notification instances (sliding window). Defaults to `10` (`30` for Telegram).            |
 
 Note that
 

--- a/src/ai_marketplace_monitor/notification.py
+++ b/src/ai_marketplace_monitor/notification.py
@@ -33,6 +33,12 @@ class NotificationConfig(BaseConfig):
     instance_rate_limit: float = 1.0  # seconds between sends per instance
     global_rate_limit: int = 10  # messages per second across all instances
 
+    # Subclasses that handle rate limiting in their own send path (e.g.
+    # Telegram's async _wait_for_rate_limit) should set this to True so
+    # the base class _execute_with_retry does NOT also apply sync rate
+    # limiting — preventing double-wait.
+    _handles_own_rate_limiting: bool = False
+
     # Private tracking attributes
     _last_send_time: float | None = None
 
@@ -146,10 +152,15 @@ class NotificationConfig(BaseConfig):
         message: str,
         logger: Logger | None = None,
     ) -> bool:
-        """Enhanced retry method with rate limiting support."""
-        return self._execute_with_retry(
-            title, message, logger, apply_rate_limiting=self.rate_limit_enabled
-        )
+        """Enhanced retry method with rate limiting support.
+
+        Subclasses that set ``_handles_own_rate_limiting = True`` (e.g.
+        Telegram, which applies async rate limiting inside its own
+        ``send_message``) will NOT get sync rate limiting here —
+        avoiding a double-wait.
+        """
+        apply = self.rate_limit_enabled and not self._handles_own_rate_limiting
+        return self._execute_with_retry(title, message, logger, apply_rate_limiting=apply)
 
     def _get_wait_time(self: "NotificationConfig") -> float:
         """Calculate instance-level wait time. Override for custom logic."""
@@ -161,7 +172,12 @@ class NotificationConfig(BaseConfig):
 
     @classmethod
     def _get_global_wait_time(cls: Type["NotificationConfig"]) -> float:
-        """Calculate global wait time across all instances."""
+        """Calculate global wait time across all instances.
+
+        Note: this is only called from _wait_for_rate_limit[_sync] which
+        already gates on rate_limit_enabled, so non-rate-limited instances
+        never reach here and never populate _global_send_times.
+        """
         with cls._global_lock:
             # Check if any instance has rate limiting enabled by checking if we have any tracked times
             # This is a more practical approach than checking class attributes

--- a/src/ai_marketplace_monitor/telegram.py
+++ b/src/ai_marketplace_monitor/telegram.py
@@ -20,8 +20,8 @@ class TelegramNotificationConfig(PushNotificationConfig):
     telegram_chat_id: str | None = None
 
     # Enable rate limiting with Telegram-specific settings
-    _rate_limit_enabled: bool = True
-    _global_rate_limit: int = 30  # Telegram's higher limit
+    rate_limit_enabled: bool = True
+    global_rate_limit: int = 30  # Telegram's higher limit
 
     def handle_telegram_token(self: "TelegramNotificationConfig") -> None:
         if self.telegram_token is None:
@@ -146,7 +146,7 @@ class TelegramNotificationConfig(PushNotificationConfig):
 
     def _get_wait_time(self: "TelegramNotificationConfig") -> float:
         """Override for Telegram's group vs individual chat logic."""
-        if not self._rate_limit_enabled or self._last_send_time is None:
+        if not self.rate_limit_enabled or self._last_send_time is None:
             return 0.0
 
         elapsed = time.time() - self._last_send_time
@@ -158,7 +158,7 @@ class TelegramNotificationConfig(PushNotificationConfig):
         self: "TelegramNotificationConfig", logger: Logger | None = None
     ) -> None:
         """Override to provide Telegram-specific logging."""
-        if not self._rate_limit_enabled:
+        if not self.rate_limit_enabled:
             return
 
         import asyncio
@@ -174,7 +174,7 @@ class TelegramNotificationConfig(PushNotificationConfig):
             if logger:
                 if global_wait > instance_wait:
                     logger.debug(
-                        f"Global rate limiting: waiting {wait_time:.1f} seconds (limit: {self._global_rate_limit} msg/sec)"
+                        f"Global rate limiting: waiting {wait_time:.1f} seconds (limit: {self.global_rate_limit} msg/sec)"
                     )
                 else:
                     chat_type = "group" if self._is_group_chat() else "individual"

--- a/src/ai_marketplace_monitor/telegram.py
+++ b/src/ai_marketplace_monitor/telegram.py
@@ -22,6 +22,9 @@ class TelegramNotificationConfig(PushNotificationConfig):
     # Enable rate limiting with Telegram-specific settings
     rate_limit_enabled: bool = True
     global_rate_limit: int = 30  # Telegram's higher limit
+    # Telegram handles rate limiting in its own async _send_message_async
+    # path — tell the base class not to also apply sync rate limiting.
+    _handles_own_rate_limiting: bool = True
 
     def handle_telegram_token(self: "TelegramNotificationConfig") -> None:
         if self.telegram_token is None:

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -271,15 +271,15 @@ class TestNotificationConfigRateLimiting:
     def base_config(self: "Self") -> NotificationConfig:
         """Create a base NotificationConfig with rate limiting enabled for testing."""
         config = NotificationConfig(name="test_base")
-        config._rate_limit_enabled = True
+        config.rate_limit_enabled = True
         return config
 
     def test_rate_limiting_disabled_by_default(self: "Self") -> None:
         """Test that rate limiting is disabled by default in base class."""
         config = NotificationConfig(name="test")
-        assert config._rate_limit_enabled is False
-        assert config._instance_rate_limit == 1.0
-        assert config._global_rate_limit == 10
+        assert config.rate_limit_enabled is False
+        assert config.instance_rate_limit == 1.0
+        assert config.global_rate_limit == 10
 
     def test_get_wait_time_disabled(self: "Self") -> None:
         """Test _get_wait_time returns 0 when rate limiting is disabled."""
@@ -314,10 +314,10 @@ class TestNotificationConfigRateLimiting:
         for _ in range(5):
             NotificationConfig._global_send_times.append(current_time - 2.0)
 
-        # Mock the class to have rate limiting enabled
-        with patch.object(NotificationConfig, "_rate_limit_enabled", True):
-            wait_time = NotificationConfig._get_global_wait_time()
-            assert wait_time == 0.0
+        # Since global rate limiting now checks for existing send times,
+        # an empty deque means no rate limiting is active
+        wait_time = NotificationConfig._get_global_wait_time()
+        assert wait_time == 0.0
 
     def test_record_global_send_time(self: "Self") -> None:
         """Test that global send times are recorded correctly."""


### PR DESCRIPTION
## Summary
- Moves rate limiting logic from Telegram-specific implementation to base `NotificationConfig` class
- All notification types can now opt-in to rate limiting via `rate_limit_enabled`, `instance_rate_limit`, and `global_rate_limit` config options
- Telegram automatically enables rate limiting with smart defaults (1.1s individual, 3.0s group chats)
- Rate limiting is disabled by default for all other notification types

Rebased from @adawalli's [adawalli/ai-marketplace-monitor#7](https://github.com/adawalli/ai-marketplace-monitor/pull/7). Resolves #235.

## Test plan
- [x] All 28 notification tests pass
- [ ] Verify Telegram rate limiting still works correctly in production
- [ ] Test opt-in rate limiting for other notification types (email, PushBullet, PushOver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limiting for notifications (instance-level and global).
  * Telegram now has automatic rate limiting with chat-type detection and optimized delays.
  * Rate limiting is opt-in for email, PushBullet, PushOver and other notification types.

* **Documentation**
  * Updated notification settings docs with new rate limiting options and detailed Telegram behavior.

* **Tests**
  * Added tests covering rate-limiting behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->