### PR TITLE
Add Anthropic/Claude as AI backend provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Anthropic/Claude as an AI backend provider with support for Claude models (default: `claude-sonnet-4-20250514`)
 - [issue 235](https://github.com/BoPeng/ai-marketplace-monitor/issues/235) Configurable rate limiting framework for all notification types
   - Rate limiting infrastructure moved from Telegram-specific to base notification class
   - Automatic rate limiting for Telegram with intelligent chat type detection (1.1s individual, 3.0s group)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ https://facebook.com/marketplace/item/1234567890
 AI: Great deal; A well-priced, well-maintained camera meets all search criteria, with extra battery and charger.
 ```
 
+## What's New
+
+- **Anthropic/Claude AI Backend**: Use Claude models (e.g. `claude-sonnet-4-20250514`) to evaluate listings alongside OpenAI, DeepSeek, and Ollama. See [AI Services](docs/README.md#ai-services) for configuration.
+- **Configurable Rate Limiting**: Rate limiting framework for all notification types with per-instance and global limits. Telegram notifications use optimized defaults automatically.
+
 **Table of Contents:**
 
+- [What's New](#whats-new)
 - [✨ Key Features](#-key-features)
 - [🚀 Quick Start](#-quick-start)
 - [💡 Example Usage](#-example-usage)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Here is a complete list of options that are acceptable by the program. [`example
 
 ### AI Services
 
-One of more sections to list the AI agent that can be used to judge if listings match your selection criteria. The options should have header such as `[ai.openai]` or `[ai.deepseek]`, and have the following keys:
+One of more sections to list the AI agent that can be used to judge if listings match your selection criteria. The options should have header such as `[ai.openai]`, `[ai.deepseek]`, or `[ai.anthropic]`, and have the following keys:
 
 | Option        | Requirement | DataType | Description                                                |
 | ------------- | ----------- | -------- | ---------------------------------------------------------- |
@@ -47,17 +47,25 @@ One of more sections to list the AI agent that can be used to judge if listings 
 Note that:
 
 1. `provider` can be [OpenAI](https://openai.com/),
-   [DeepSeek](https://www.deepseek.com/), or [Ollama](https://ollama.com/). The name of the ai service will be used if this option is not specified so `OpenAI` will be used for section `ai.openai`.
+   [DeepSeek](https://www.deepseek.com/), [Ollama](https://ollama.com/), or [Anthropic](https://www.anthropic.com/). The name of the ai service will be used if this option is not specified so `OpenAI` will be used for section `ai.openai`.
 2. [OpenAI](https://openai.com/) and [DeepSeek](https://www.deepseek.com/) models sets default `base_url` and `model` for these providers.
 3. Ollama models require `base_url`. A default model is set to `deepseek-r1:14b`, which seems to be good enough for this application. You can of course try [other models](https://ollama.com/library) by setting the `model` option.
-4. Although only three providers are supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api_key`.
-5. You can use option `ai` to list the AI services for particular marketplaces or items.
+4. [Anthropic](https://www.anthropic.com/) uses the Anthropic SDK directly (not OpenAI-compatible). The default model is `claude-sonnet-4-20250514`. An `api_key` is required.
+5. Although only four providers are directly supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api_key`.
+6. You can use option `ai` to list the AI services for particular marketplaces or items.
 
 A typical section for OpenAI looks like
 
 ```toml
 [ai.openai]
 api_key = 'sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+```
+
+A typical section for Anthropic looks like
+
+```toml
+[ai.anthropic]
+api_key = 'sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 ```
 
 ### Marketplaces

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -5,6 +5,10 @@
 api_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 model = "gpt-4o"
 
+# [ai.anthropic]
+# api_key = 'sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+# model = "claude-sonnet-4-20250514"
+
 #
 # Marketplace
 #

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -67,7 +67,7 @@ Create a minimal configuration file at ``~/.ai-marketplace-monitor/config.toml``
 Step 4: Add AI Service (Optional but Recommended)
 ------------------------------------------------
 
-Sign up for an AI service like `OpenAI <https://openai.com/>`_ or `DeepSeek <https://www.deepseek.com/>`_ and add to your config:
+Sign up for an AI service like `OpenAI <https://openai.com/>`_, `DeepSeek <https://www.deepseek.com/>`_, or `Anthropic <https://www.anthropic.com/>`_ and add to your config:
 
 .. code-block:: toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "diskcache>=5.6.3",
   "watchdog>=4.0.0",
   "openai>=1.24.0",
+  "anthropic>=0.39.0",
   "parsedatetime>=2.5",
   "humanize>=4.0.0",
   "schedule>=1.2.2",

--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -163,7 +163,7 @@ class AIBackend(Generic[TAIConfig]):
     def __init__(self: "AIBackend", config: AIConfig, logger: Logger | None = None) -> None:
         self.config = config
         self.logger = logger
-        self.client: OpenAI | None = None
+        self.client: Any = None
 
     @classmethod
     def get_config(cls: Type["AIBackend"], **kwargs: Any) -> TAIConfig:

--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -18,6 +18,7 @@ class AIServiceProvider(Enum):
     OPENAI = "OpenAI"
     DEEPSEEK = "DeepSeek"
     OLLAMA = "Ollama"
+    ANTHROPIC = "Anthropic"
 
 
 @dataclass
@@ -146,6 +147,13 @@ class OllamaConfig(OpenAIConfig):
     def handle_model(self: "OllamaConfig") -> None:
         if self.model is None:
             raise ValueError("Ollama requires a string model.")
+
+
+@dataclass
+class AnthropicConfig(AIConfig):
+    def handle_api_key(self: "AnthropicConfig") -> None:
+        if self.api_key is None:
+            raise ValueError("Anthropic requires a string api_key.")
 
 
 TAIConfig = TypeVar("TAIConfig", bound=AIConfig)
@@ -366,3 +374,99 @@ class OllamaBackend(OpenAIBackend):
     @classmethod
     def get_config(cls: Type["OllamaBackend"], **kwargs: Any) -> OllamaConfig:
         return OllamaConfig(**kwargs)
+
+
+class AnthropicBackend(AIBackend):
+    default_model = "claude-sonnet-4-20250514"
+
+    @classmethod
+    def get_config(cls: Type["AnthropicBackend"], **kwargs: Any) -> AnthropicConfig:
+        return AnthropicConfig(**kwargs)
+
+    def connect(self: "AnthropicBackend") -> None:
+        if self.client is None:
+            import anthropic  # type: ignore
+
+            self.client = anthropic.Anthropic(
+                api_key=self.config.api_key,
+                timeout=self.config.timeout,
+            )
+            if self.logger:
+                self.logger.info(f"""{hilight("[AI]", "name")} {self.config.name} connected.""")
+
+    def evaluate(
+        self: "AnthropicBackend",
+        listing: Listing,
+        item_config: TItemConfig,
+        marketplace_config: TMarketplaceConfig,
+    ) -> AIResponse:
+        counter.increment(CounterItem.AI_QUERY, item_config.name)
+        prompt = self.get_prompt(listing, item_config, marketplace_config)
+        res: AIResponse | None = AIResponse.from_cache(listing, item_config, marketplace_config)
+        if res is not None:
+            if self.logger:
+                self.logger.debug(
+                    f"""{hilight("[AI]", res.style)} {self.config.name} previously concluded {hilight(f"{res.conclusion} ({res.score}): {res.comment}", res.style)} for listing {hilight(listing.title)}."""
+                )
+            return res
+
+        self.connect()
+
+        retries = 0
+        while retries < self.config.max_retries:
+            self.connect()
+            assert self.client is not None
+            try:
+                response = self.client.messages.create(
+                    model=self.config.model or self.default_model,
+                    max_tokens=1024,
+                    system="You are a helpful assistant that can confirm if a user's search criteria matches the item he is interested in.",
+                    messages=[
+                        {"role": "user", "content": prompt},
+                    ],
+                )
+                break
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"""{hilight("[AI-Error]", "fail")} {self.config.name} failed to evaluate {hilight(listing.title)}: {e}"""
+                    )
+                retries += 1
+                self.client = None
+                time.sleep(5)
+
+        if self.logger:
+            self.logger.debug(f"""{hilight("[AI-Response]", "info")} {pretty_repr(response)}""")
+
+        answer = response.content[0].text if response.content else ""
+        if (
+            answer is None
+            or not answer.strip()
+            or re.search(r"Rating[^1-5]*[1-5]", answer, re.DOTALL) is None
+        ):
+            counter.increment(CounterItem.FAILED_AI_QUERY, item_config.name)
+            raise ValueError(f"Empty or invalid response from {self.config.name}: {response}")
+
+        lines = answer.split("\n")
+        score: int = 1
+        comment = ""
+        rating_line = None
+        for idx, line in enumerate(lines):
+            matched = re.match(r".*Rating[^1-5]*([1-5])[:\s]*(.*)", line)
+            if matched:
+                score = int(matched.group(1))
+                comment = matched.group(2).strip()
+                rating_line = idx
+                continue
+            if rating_line is not None:
+                comment += " " + line
+        if len(comment.strip()) < 5 and rating_line is not None and rating_line > 0:
+            comment = lines[rating_line - 1]
+
+        comment = " ".join([x for x in comment.split() if x.strip()]).strip()
+        res = AIResponse(name=self.config.name, score=score, comment=comment)
+        res.to_cache(listing, item_config, marketplace_config)
+        counter.increment(CounterItem.NEW_AI_QUERY, item_config.name)
+        return res

--- a/src/ai_marketplace_monitor/config.py
+++ b/src/ai_marketplace_monitor/config.py
@@ -11,7 +11,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from .ai import DeepSeekBackend, OllamaBackend, OpenAIBackend, TAIConfig
+from .ai import AnthropicBackend, DeepSeekBackend, OllamaBackend, OpenAIBackend, TAIConfig
 from .facebook import FacebookMarketplace
 from .marketplace import TItemConfig, TMarketplaceConfig
 from .notification import NotificationConfig
@@ -24,6 +24,7 @@ supported_ai_backends = {
     "deepseek": DeepSeekBackend,
     "openai": OpenAIBackend,
     "ollama": OllamaBackend,
+    "anthropic": AnthropicBackend,
 }
 
 


### PR DESCRIPTION
## Summary
- Add Anthropic as a new AI service provider alongside OpenAI, DeepSeek, and Ollama
- Implement `AnthropicBackend` and `AnthropicConfig` classes using the native Anthropic SDK (`anthropic` package)
- Default model is `claude-sonnet-4-20250514`; configurable via `model` in config

## Usage
```toml
[ai.claude]
provider = "anthropic"
api_key = "sk-ant-..."
# model = "claude-sonnet-4-20250514"  # optional, this is the default
```

## Test plan
- [ ] Verify Anthropic backend connects and evaluates listings correctly
- [ ] Verify config parsing accepts `provider = "anthropic"` 
- [ ] Verify existing OpenAI/DeepSeek/Ollama backends are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anthropic (Claude) as a supported AI service provider for listing evaluation.
* **Configuration**
  * AI configuration now accepts an Anthropic provider section and corresponding model/api_key settings.
* **Documentation**
  * Updated README, quickstart, examples, and docs to document Anthropic support and a “What’s New” section.
* **Changelog**
  * Noted Anthropic support and default model entry under Unreleased Added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->