### PR TITLE
Switch release workflow to PyPI trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,8 @@ jobs:
 
       - name: Publish package on PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          attestations: false
 
       - name: Publish package on TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-          attestations: false


### PR DESCRIPTION
Replace token-based authentication with OpenID Connect trusted publisher. This eliminates the need for PYPI_TOKEN and TEST_PYPI_TOKEN secrets — the id-token: write permission handles auth via OIDC.
