### PR TITLE
Add Python 3.10+ requirement note to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ AI: Great deal; A well-priced, well-maintained camera meets all search criteria,
 
 ### Installation
 
+> **Requires Python 3.10 or higher.** Check your version with `python --version`. If your system default is older, use `pip3.10` (or `pip3.11`, `pip3.12`, etc.) instead of `pip`, or create a virtual environment with the correct version.
+
 ```bash
 pip install ai-marketplace-monitor
 playwright install


### PR DESCRIPTION
## Summary
- Adds a visible note about the Python 3.10+ requirement before the `pip install` command in the README's Quick Start section
- Suggests using `pip3.10`/`pip3.11`/etc. or a virtual environment if the system Python is older

Closes #302

## Test plan
- [ ] Verify the note renders correctly in the README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Python 3.10+ version requirement to installation instructions with guidance on verifying Python version and configuring the appropriate environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->