### PR TITLE
Fix stale runtime version reporting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,15 +1,11 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.2.0
+current_version = 0.10.1
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
-
-[bumpversion:file:src/ai_marketplace_monitor/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
 
 [bumpversion:file(title):CHANGELOG.md]
 search = {#}{#} [Unreleased]

--- a/src/ai_marketplace_monitor/__init__.py
+++ b/src/ai_marketplace_monitor/__init__.py
@@ -1,5 +1,11 @@
 """Top-level package for ai-marketplace-monitor."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 __author__ = """Bo Peng"""
 __email__ = "ben.bob@gmail.com"
-__version__ = "0.9.11"
+
+try:
+    __version__ = version("ai-marketplace-monitor")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"

--- a/tests/test_aimm.py
+++ b/tests/test_aimm.py
@@ -13,7 +13,7 @@ from ai_marketplace_monitor.user import User
 
 def test_version(version: str) -> None:
     """Sample pytest test function with the pytest fixture as an argument."""
-    assert version == "0.9.11"
+    assert version and version[0].isdigit()
 
 
 def test_listing_cache(temp_cache: Cache, listing: Listing) -> None:


### PR DESCRIPTION
## Summary
- Runtime was logging `[VERSION] AI Marketplace Monitor, version 0.9.11` despite PyPI being on 0.10.1
- Version bump commits updated `pyproject.toml` but missed the hardcoded `__version__` in `src/ai_marketplace_monitor/__init__.py`
- Switch `__init__.py` to read the version via `importlib.metadata.version()` so it stays in sync with the installed package automatically
- Remove the now-redundant `__init__.py` entry from `.bumpversion.cfg` and sync its stale `current_version` (0.2.0 → 0.10.1)

This also explains the confusion in #309, where the reporter said they were on 0.9.11 even though the web UI (added in 0.10.0) was running.

## Test plan
- [x] `python -c "from ai_marketplace_monitor import __version__; print(__version__)"` prints `0.10.1`
- [ ] Running `ai-marketplace-monitor` logs the correct version at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.10.1
  * Updated version management configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->