### PR TITLE
Fix WebUI startup failure on older FastAPI versions

### DIFF
--- a/src/ai_marketplace_monitor/webui/server.py
+++ b/src/ai_marketplace_monitor/webui/server.py
@@ -306,7 +306,7 @@ def create_app(
         body: Dict[str, Any],
         _: str = Depends(require_session),
         __: None = Depends(require_csrf),
-    ) -> Dict[str, Any] | JSONResponse:
+    ) -> Dict[str, Any]:
         content = body.get("content")
         if not isinstance(content, str):
             raise HTTPException(status_code=400, detail="Missing 'content' field")
@@ -319,7 +319,7 @@ def create_app(
             raise HTTPException(status_code=404, detail=str(e)) from None
         if not ok:
             status_code = 409 if error and "conflict" in error else 400
-            return JSONResponse(
+            return JSONResponse(  # type: ignore[return-value]
                 status_code=status_code,
                 content={"ok": False, "error": error, "mtime": new_mtime},
             )


### PR DESCRIPTION
## Summary
The `put_config_file` endpoint in `webui/server.py` declared its return type as `Dict[str, Any] | JSONResponse`. Older FastAPI/Pydantic versions hand the full `Union` to Pydantic when building the response model, and Pydantic cannot build a field schema for `JSONResponse` (a Starlette class), causing startup to fail with:

```
FastAPIError: Invalid args for response field! Hint: check that
typing.Union[typing.Dict, starlette.responses.JSONResponse] is a
valid Pydantic field type.
```

Newer FastAPI versions special-case `Response` subclasses inside a `Union`, which is why the bug only surfaced on some users' installs (see #309).

Removing `JSONResponse` from the annotation is safe: FastAPI passes `Response` instances through untouched regardless of the declared return type, so the error branch that returns a `JSONResponse` still works correctly.

Fixes #309

## Test plan
- [ ] WebUI starts successfully
- [ ] `PUT /api/config/file/{file_id}` with valid content returns 200 with the dict payload
- [ ] `PUT /api/config/file/{file_id}` with a conflicting `base_mtime` returns 409 with the JSON error body

🤖 Generated with [Claude Code](https://claude.com/claude-code)