### PR TITLE
Add car-flipping pipeline: rule-based scorer, plate OCR, NZTA WOF gating, analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,13 @@ dmypy.json
 
 # Code editors
 .vscode
+
+# Plate-OCR model binaries (auto-downloaded on first run / via scripts/warmup-plate-ocr.bat)
+models/
+*.onnx
+
+# Runtime analytics database
+data/
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm

--- a/scripts/warmup-plate-ocr.bat
+++ b/scripts/warmup-plate-ocr.bat
@@ -1,0 +1,37 @@
+@echo off
+REM ============================================================
+REM  Pre-download & warm up the plate detector + OCR models.
+REM
+REM  Why this batch file exists:
+REM  -----------------------------
+REM  `python` on this machine resolves to Inkscape's bundled
+REM  interpreter, which does NOT have aimm installed.
+REM  The real Python (where pip put fast-plate-ocr) lives at:
+REM     %LOCALAPPDATA%\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.13...
+REM  This script picks the right one explicitly.
+REM ============================================================
+
+setlocal
+
+REM Prefer the Windows Store Python (the one `pip install` actually targets here).
+set "PY=%LOCALAPPDATA%\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\python.exe"
+
+if not exist "%PY%" (
+    REM Fall back to the `py` launcher.
+    where py >nul 2>&1
+    if errorlevel 1 (
+        echo [ERROR] Could not find Python 3.13. Install from the Microsoft Store or python.org.
+        exit /b 1
+    )
+    set "PY=py -3.13"
+)
+
+echo Using interpreter: %PY%
+echo.
+
+REM Resolve repo root (parent of /scripts).
+set "REPO=%~dp0.."
+
+"%PY%" -c "import sys; sys.path.insert(0, r'%REPO%\src'); import logging; logging.basicConfig(level=logging.INFO); from ai_marketplace_monitor.plate_ocr import _ensure_models; _ensure_models(logging.getLogger('warmup')); print('Models ready.')"
+
+endlocal

--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -387,10 +387,19 @@ class AnthropicBackend(AIBackend):
         if self.client is None:
             import anthropic  # type: ignore
 
-            self.client = anthropic.Anthropic(
-                api_key=self.config.api_key,
-                timeout=self.config.timeout,
-            )
+            api_key = self.config.api_key or ""
+            # OAuth access tokens (sk-ant-oat…) must be passed as auth_token,
+            # not api_key, so the SDK sends them as a Bearer header.
+            if api_key.startswith("sk-ant-oat"):
+                self.client = anthropic.Anthropic(
+                    auth_token=api_key,
+                    timeout=self.config.timeout,
+                )
+            else:
+                self.client = anthropic.Anthropic(
+                    api_key=api_key,
+                    timeout=self.config.timeout,
+                )
             if self.logger:
                 self.logger.info(f"""{hilight("[AI]", "name")} {self.config.name} connected.""")
 

--- a/src/ai_marketplace_monitor/analytics_db.py
+++ b/src/ai_marketplace_monitor/analytics_db.py
@@ -1,0 +1,167 @@
+"""Analytics SQLite database for marketplace listings.
+
+Captures everything we learn about each listing — title, price (as numeric
+int for analysis), location, plate, WOF/rego expiry/status, vehicle make &
+model, and whether we ended up notifying — so you can run SQL against the
+data later (price trends, WOF correlation, hit rate, etc.).
+
+The DB lives at <repo>/data/analytics.sqlite by default. Override via
+AIMM_ANALYTICS_DB env var.
+"""
+
+import os
+import pathlib
+import re
+import sqlite3
+import threading
+from datetime import datetime
+from logging import Logger
+from typing import Any, Optional
+
+_PKG_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = pathlib.Path(
+    os.environ.get("AIMM_ANALYTICS_DB") or (_PKG_ROOT / "data" / "analytics.sqlite")
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS listings (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    seen_at              TEXT    NOT NULL,
+    marketplace          TEXT,
+    listing_id           TEXT,
+    item_name            TEXT,
+    title                TEXT,
+    price_raw            TEXT,
+    price_value          REAL,
+    price_currency       TEXT,
+    location             TEXT,
+    post_url             TEXT,
+    seller               TEXT,
+    description          TEXT,
+    -- Algorithmic score
+    score                INTEGER,
+    rejection_level      TEXT,
+    -- Plate & WOF/Rego
+    plate                TEXT,
+    plate_source         TEXT,           -- 'text' | 'ocr' | NULL
+    vehicle              TEXT,           -- '1996 TOYOTA CELICA'
+    colour               TEXT,
+    wof_expiry           TEXT,
+    wof_status           TEXT,           -- 'Current' | 'Expired' | 'Unknown'
+    wof_days_remaining   INTEGER,
+    rego_expiry          TEXT,
+    rego_status          TEXT,
+    rego_days_remaining  INTEGER,
+    -- Outcome
+    notified             INTEGER NOT NULL DEFAULT 0,
+    skip_reason          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_listings_seen_at ON listings(seen_at);
+CREATE INDEX IF NOT EXISTS idx_listings_listing_id ON listings(listing_id);
+CREATE INDEX IF NOT EXISTS idx_listings_plate ON listings(plate);
+CREATE INDEX IF NOT EXISTS idx_listings_notified ON listings(notified);
+"""
+
+
+_lock = threading.Lock()
+_conn: Optional[sqlite3.Connection] = None
+_db_path: Optional[pathlib.Path] = None
+
+
+def _get_conn(db_path: pathlib.Path = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    global _conn, _db_path
+    with _lock:
+        if _conn is not None and _db_path == db_path:
+            return _conn
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.executescript(_SCHEMA)
+        _conn = conn
+        _db_path = db_path
+        return _conn
+
+
+_PRICE_RE = re.compile(r"([A-Z$€£¥]{0,3})\s*([\d,]+(?:\.\d{1,2})?)")
+
+
+def parse_price(raw: Optional[str]) -> tuple[Optional[float], Optional[str]]:
+    """'NZ$1,900' → (1900.0, 'NZ$'). Returns (None, None) if unparseable."""
+    if not raw:
+        return None, None
+    m = _PRICE_RE.search(raw.strip())
+    if not m:
+        return None, None
+    currency = (m.group(1) or "").strip() or None
+    try:
+        value = float(m.group(2).replace(",", ""))
+    except (ValueError, AttributeError):
+        return None, currency
+    return value, currency
+
+
+def record_listing(
+    *,
+    listing,
+    item_name: Optional[str] = None,
+    score: Optional[int] = None,
+    rejection_level: Optional[str] = None,
+    plate: Optional[str] = None,
+    plate_source: Optional[str] = None,
+    wof=None,                    # WOFResult-like or None
+    notified: bool = False,
+    skip_reason: Optional[str] = None,
+    db_path: pathlib.Path = DEFAULT_DB_PATH,
+    logger: Optional[Logger] = None,
+) -> Optional[int]:
+    """Insert a row for this listing. Returns the new row id, or None on error."""
+    try:
+        price_value, price_currency = parse_price(getattr(listing, "price", None))
+        row = {
+            "seen_at":             datetime.now().isoformat(timespec="seconds"),
+            "marketplace":         getattr(listing, "marketplace", None),
+            "listing_id":          getattr(listing, "id", None),
+            "item_name":           item_name,
+            "title":               getattr(listing, "title", None),
+            "price_raw":           getattr(listing, "price", None),
+            "price_value":         price_value,
+            "price_currency":      price_currency,
+            "location":            getattr(listing, "location", None),
+            "post_url":            getattr(listing, "post_url", None),
+            "seller":              getattr(listing, "seller", None),
+            "description":         getattr(listing, "description", None),
+            "score":               score,
+            "rejection_level":     rejection_level,
+            "plate":               plate,
+            "plate_source":        plate_source,
+            "vehicle":             getattr(wof, "vehicle", None) if wof else None,
+            "colour":              getattr(wof, "colour", None) if wof else None,
+            "wof_expiry":          getattr(wof, "wof_expiry", None) if wof else None,
+            "wof_status":          getattr(wof, "wof_status", None) if wof else None,
+            "wof_days_remaining":  getattr(wof, "wof_days_remaining", None) if wof else None,
+            "rego_expiry":         getattr(wof, "rego_expiry", None) if wof else None,
+            "rego_status":         getattr(wof, "rego_status", None) if wof else None,
+            "rego_days_remaining": getattr(wof, "rego_days_remaining", None) if wof else None,
+            "notified":            1 if notified else 0,
+            "skip_reason":         skip_reason,
+        }
+        cols = ", ".join(row.keys())
+        placeholders = ", ".join(f":{k}" for k in row.keys())
+        conn = _get_conn(db_path)
+        with _lock:
+            cur = conn.execute(
+                f"INSERT INTO listings ({cols}) VALUES ({placeholders})", row
+            )
+            return cur.lastrowid
+    except Exception as e:
+        if logger:
+            logger.debug(f"[Analytics] DB insert failed: {e}")
+        return None
+
+
+def query(sql: str, params: tuple = (), db_path: pathlib.Path = DEFAULT_DB_PATH) -> list[Any]:
+    """Convenience query helper for ad-hoc analysis."""
+    conn = _get_conn(db_path)
+    with _lock:
+        return list(conn.execute(sql, params))

--- a/src/ai_marketplace_monitor/facebook.py
+++ b/src/ai_marketplace_monitor/facebook.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import random
 import re
 import time
 from dataclasses import dataclass
@@ -18,9 +19,11 @@ from .listing import Listing
 from .marketplace import ItemConfig, Marketplace, MarketplaceConfig, WebPage
 from .utils import (
     BaseConfig,
+    CacheType,
     CounterItem,
     KeyboardMonitor,
     Translator,
+    cache,
     convert_to_seconds,
     counter,
     doze,
@@ -311,20 +314,30 @@ class FacebookMarketplace(Marketplace):
                     f"{hilight('[Login]', 'fail')} Could not handle cookie pop-up (or it was not present): {e!s}"
                 )
 
+        # Humanise the login flow so FB's bot detector doesn't trip.
+        from .human_actions import human_mouse_jitter, human_sleep, human_type
+
         self.config: FacebookMarketplaceConfig
         try:
+            # Small idle: humans look around before typing.
+            human_mouse_jitter(self.page, moves=random.randint(2, 4))
+            human_sleep(0.8, 2.2)
+
             if self.config.username:
-                time.sleep(2)
                 selector = self.page.wait_for_selector('input[name="email"]')
                 if selector is not None:
-                    selector.type(self.config.username, delay=250)
+                    human_type(selector, self.config.username, base_delay_ms=90)
+                human_sleep(0.6, 1.6)
+
             if self.config.password:
-                time.sleep(2)
                 selector = self.page.wait_for_selector('input[name="pass"]')
                 if selector is not None:
-                    selector.type(self.config.password, delay=250)
+                    human_type(selector, self.config.password, base_delay_ms=95)
+                human_sleep(0.7, 1.9)
+
             if self.config.username and self.config.password:
-                time.sleep(2)
+                # Pre-click mouse path so the click isn't teleported.
+                human_mouse_jitter(self.page, moves=2)
                 selector = self.page.wait_for_selector('button[name="login"]')
                 if selector is not None:
                     selector.click()
@@ -357,7 +370,7 @@ class FacebookMarketplace(Marketplace):
             self.login()
             assert self.page is not None
 
-        options = []
+        options = ["sortBy=creation_time_descend"]
 
         condition = item_config.condition or self.config.condition
         if condition:
@@ -403,6 +416,8 @@ class FacebookMarketplace(Marketplace):
         # search multiple keywords and cities
         # there is a small chance that search by different keywords and city will return the same items.
         found = {}
+        seen_key = (CacheType.SEEN_LISTINGS.value, item_config.name)
+        seen_listing_ids: set = cache.get(seen_key) or set()
         search_city = item_config.search_city or self.config.search_city or []
         city_name = item_config.city_name or self.config.city_name or []
         radiuses = item_config.radius or self.config.radius
@@ -483,14 +498,19 @@ class FacebookMarketplace(Marketplace):
                     marketplace_url + "&".join([f"query={quote(search_phrase)}", *options])
                 )
 
+                # Human-ish post-load behaviour: small idle + scroll so FB's
+                # behavioural model sees us "reading" results.
+                try:
+                    from .human_actions import human_mouse_jitter, human_scroll, human_sleep
+                    human_sleep(0.6, 1.6)
+                    human_mouse_jitter(self.page, moves=random.randint(1, 3))
+                    human_scroll(self.page, steps=random.randint(1, 3))
+                except Exception:
+                    pass
+
                 found_listings = FacebookSearchResultPage(
                     self.page, self.translator, self.logger
                 ).get_listings()
-                time.sleep(5)
-                if self.logger:
-                    self.logger.error(
-                        f"""{hilight("[Search]", "fail")} Failed to get search results for {search_phrase} from {city}"""
-                    )
 
                 counter.increment(CounterItem.SEARCH_PERFORMED, item_config.name)
 
@@ -501,55 +521,29 @@ class FacebookMarketplace(Marketplace):
                         continue
                     if self.keyboard_monitor is not None and self.keyboard_monitor.is_paused():
                         return
+                    # skip listings already fully examined in previous search runs
+                    if listing.id in seen_listing_ids:
+                        continue
                     counter.increment(CounterItem.LISTING_EXAMINED, item_config.name)
                     found[listing.post_url.split("?")[0]] = True
                     # filter by title and location; skip keyword filtering since we do not have description yet.
                     if not self.check_listing(listing, item_config, description_available=False):
+                        seen_listing_ids.add(listing.id)
                         counter.increment(CounterItem.EXCLUDED_LISTING, item_config.name)
                         continue
-                    try:
-                        details, from_cache = self.get_listing_details(
-                            listing.post_url,
-                            item_config,
-                            price=listing.price,
-                            title=listing.title,
-                        )
-                        if not from_cache:
-                            time.sleep(5)
-                    except KeyboardInterrupt:
-                        raise
-                    except Exception as e:
-                        if self.logger:
-                            self.logger.error(
-                                f"""{hilight("[Retrieve]", "fail")} Failed to get item details: {e}"""
-                            )
-                        continue
-                    # currently we trust the other items from summary page a bit better
-                    # so we do not copy title, description etc from the detailed result
-                    for attr in ("condition", "seller", "description"):
-                        # other attributes should be consistent
-                        setattr(listing, attr, getattr(details, attr))
+                    # FAST PATH: skip detail page entirely — yield from search page data
                     listing.name = item_config.name
+                    seen_listing_ids.add(listing.id)
+                    # Persist immediately so a mid-loop crash / Ctrl+C doesn't
+                    # cause every "new" listing to be re-sent next cycle.
+                    cache.set(seen_key, seen_listing_ids, tag=CacheType.SEEN_LISTINGS.value)
                     if self.logger:
-                        self.logger.debug(
-                            f"""{hilight("[Retrieve]", "succ")} New item "{listing.title}" from {listing.post_url} is sold by "{listing.seller}" and with description "{listing.description[:100]}..." """
+                        self.logger.info(
+                            f"""{hilight("[New]", "succ")} {hilight(listing.title)} - {listing.price} in {listing.location}"""
                         )
+                    yield listing
 
-                    # Warn if we never managed to extract a description for keyword-based filtering
-                    if (
-                        (not listing.description or len(listing.description.strip()) == 0)
-                        and item_config.keywords
-                        and len(item_config.keywords) > 0
-                        and self.logger
-                    ):
-                        self.logger.debug(
-                            f"""{hilight("[Error]", "fail")} Failed to extract description for {hilight(listing.title)} at {listing.post_url}. Keyword filtering will only apply to title."""
-                        )
-
-                    if self.check_listing(listing, item_config):
-                        yield listing
-                    else:
-                        counter.increment(CounterItem.EXCLUDED_LISTING, item_config.name)
+                cache.set(seen_key, seen_listing_ids, tag=CacheType.SEEN_LISTINGS.value)
 
     def get_listing_details(
         self: "FacebookMarketplace",
@@ -699,6 +693,83 @@ class FacebookSearchResultPage(WebPage):
                 )
         return valid_listings
 
+    def _get_listings_from_aria_labels(self: "FacebookSearchResultPage") -> List[Listing]:
+        """Fast extraction using aria-label attributes on marketplace links.
+
+        The aria-label has format: "Title, $Price, Location, listing ID"
+        This avoids deep DOM traversal entirely.
+        """
+        listings: List[Listing] = []
+        try:
+            links = self.page.query_selector_all('a[aria-label*="listing"][href*="/marketplace/item/"]')
+            for link in links:
+                try:
+                    aria = link.get_attribute("aria-label") or ""
+                    href = link.get_attribute("href") or ""
+                    if not aria or not href:
+                        continue
+
+                    # Extract listing ID from aria-label: "..., listing 1234567890"
+                    listing_match = re.search(r"listing\s+(\d+)", aria)
+                    if not listing_match:
+                        continue
+                    listing_id = listing_match.group(1)
+
+                    # Parse aria-label: "Title, $Price, Location, listing ID"
+                    # Split from the right to handle commas in titles
+                    parts = aria.rsplit(", listing ", 1)[0]  # remove "listing ID"
+                    # Try to find price pattern
+                    price_match = re.search(r"[\$€£¥]\s?[\d,]+(?:\.\d{2})?", parts)
+                    if price_match:
+                        price_str = price_match.group(0)
+                        price_idx = parts.index(price_str)
+                        title = parts[:price_idx].rstrip(", ").strip()
+                        after_price = parts[price_idx + len(price_str):].lstrip(", ").strip()
+                        location = after_price
+                    else:
+                        # Fallback: split by last commas
+                        segments = parts.rsplit(", ", 2)
+                        title = segments[0] if len(segments) > 0 else ""
+                        price_str = segments[1] if len(segments) > 1 else ""
+                        location = segments[2] if len(segments) > 2 else ""
+
+                    price = extract_price(price_str)
+                    post_url = f"https://www.facebook.com{href}" if href.startswith("/") else href
+
+                    # Get image
+                    img = link.query_selector("img")
+                    image = (img.get_attribute("src") or "") if img else ""
+                    if image.startswith("/"):
+                        image = f"https://www.facebook.com{image}"
+
+                    listings.append(
+                        Listing(
+                            marketplace="facebook",
+                            name="",
+                            id=listing_id,
+                            title=title,
+                            image=image,
+                            price=price,
+                            post_url=post_url,
+                            location=location,
+                            condition="",
+                            seller="",
+                            description="",
+                        )
+                    )
+                except KeyboardInterrupt:
+                    raise
+                except Exception:
+                    continue
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            if self.logger:
+                self.logger.debug(
+                    f"{hilight('[Retrieve]', 'fail')} aria-label parsing failed: {e}"
+                )
+        return listings
+
     def get_listings(self: "FacebookSearchResultPage") -> List[Listing]:
         # if no result is found
         btn = self.page.locator(f"""span:has-text('{self.translator("Browse Marketplace")}')""")
@@ -713,7 +784,12 @@ class FacebookSearchResultPage(WebPage):
                 self.logger.info(f"{hilight('[Retrieve]', 'dim')} {msg}")
             return []
 
-        # find the grid box
+        # Fast path: parse aria-label attributes directly (no DOM traversal)
+        listings = self._get_listings_from_aria_labels()
+        if listings:
+            return listings
+
+        # Fallback: deep DOM traversal
         try:
             valid_listings = (
                 self._get_listing_elements_by_traversing_header()
@@ -731,7 +807,7 @@ class FacebookSearchResultPage(WebPage):
                 f.write(self.page.content())
             return []
 
-        listings: List[Listing] = []
+        listings = []
         for idx, listing in enumerate(valid_listings):
             try:
                 atag = listing.query_selector(
@@ -769,9 +845,6 @@ class FacebookSearchResultPage(WebPage):
                         title=title,
                         image=image,
                         price=price,
-                        # all the ?referral_code&referral_sotry_type etc
-                        # could be helpful for live navigation, but will be stripped
-                        # for caching item details.
                         post_url=post_url,
                         location=location,
                         condition="",

--- a/src/ai_marketplace_monitor/human_actions.py
+++ b/src/ai_marketplace_monitor/human_actions.py
@@ -1,0 +1,190 @@
+"""Human-like browser actions to avoid bot detection.
+
+The Facebook captcha trigger is usually one of:
+  1. `navigator.webdriver === true`  (Playwright default — instant flag)
+  2. Headless fingerprint (missing plugins/languages/UA-CH, no chrome.runtime)
+  3. Uniform per-key typing delay (`page.fill` is instant, `type(delay=250)` is too regular)
+  4. No mouse movement, no scrolling, no idle time between actions
+
+This module bundles the mitigations:
+  - HUMAN_LAUNCH_ARGS   : Chromium flags that strip the automation banner
+  - HUMAN_CONTEXT_OPTS  : sensible UA/viewport/locale/timezone for AKL traffic
+  - STEALTH_INIT_SCRIPT : JS executed on every new doc to undo webdriver tells
+  - human_sleep         : random sleep with jitter
+  - human_type          : per-char typing with variable delay + occasional pauses
+  - human_mouse_jitter  : small idle mouse path
+  - apply_stealth(ctx)  : one-shot setup for a Playwright context
+"""
+
+import random
+import time
+from typing import Any, Dict
+
+
+# --- Stealth knobs ---------------------------------------------------------
+
+# Chromium launch args. Removes the "Chrome is being controlled by automated
+# test software" banner and a couple of headless tells.
+HUMAN_LAUNCH_ARGS = [
+    "--disable-blink-features=AutomationControlled",
+    "--disable-features=IsolateOrigins,site-per-process",
+    "--no-default-browser-check",
+    "--no-first-run",
+    "--password-store=basic",
+    "--use-mock-keychain",
+]
+
+# Recent real Chrome UA. Refresh this every few months.
+DEFAULT_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+
+# Per-call context options. Slight viewport randomisation keeps fingerprints
+# from being byte-identical across runs.
+def human_context_opts(locale: str = "en-NZ", timezone: str = "Pacific/Auckland") -> Dict[str, Any]:
+    viewports = [
+        {"width": 1366, "height": 768},
+        {"width": 1440, "height": 900},
+        {"width": 1536, "height": 864},
+        {"width": 1600, "height": 900},
+        {"width": 1920, "height": 1080},
+    ]
+    return {
+        "user_agent": DEFAULT_UA,
+        "viewport": random.choice(viewports),
+        "locale": locale,
+        "timezone_id": timezone,
+        "device_scale_factor": random.choice([1, 1, 2]),  # mostly 1
+        "is_mobile": False,
+        "has_touch": False,
+        "java_script_enabled": True,
+        "color_scheme": "light",
+        "extra_http_headers": {
+            "Accept-Language": f"{locale},en;q=0.9",
+            "Sec-Ch-Ua": '"Chromium";v="131", "Not_A Brand";v="24"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
+        },
+    }
+
+
+# Run-on-new-document script that removes the obvious webdriver tells.
+STEALTH_INIT_SCRIPT = r"""
+(() => {
+  // 1. navigator.webdriver -> undefined
+  try {
+    Object.defineProperty(Navigator.prototype, 'webdriver', {get: () => undefined});
+  } catch (e) {}
+
+  // 2. Plugins & mimeTypes — Playwright/Chromium-headless leaves these empty.
+  try {
+    Object.defineProperty(navigator, 'plugins', {
+      get: () => [{name: 'PDF Viewer'}, {name: 'Chrome PDF Viewer'}, {name: 'Native Client'}],
+    });
+    Object.defineProperty(navigator, 'mimeTypes', {get: () => [1, 2, 3]});
+  } catch (e) {}
+
+  // 3. Languages
+  try {
+    Object.defineProperty(navigator, 'languages', {get: () => ['en-NZ', 'en']});
+  } catch (e) {}
+
+  // 4. chrome.runtime — present in real Chrome, missing in headless
+  if (!window.chrome) { window.chrome = {}; }
+  if (!window.chrome.runtime) { window.chrome.runtime = {}; }
+
+  // 5. permissions query — headless reports 'denied' for notifications even when default
+  try {
+    const orig = window.navigator.permissions.query.bind(window.navigator.permissions);
+    window.navigator.permissions.query = (p) => (
+      p && p.name === 'notifications'
+        ? Promise.resolve({state: Notification.permission})
+        : orig(p)
+    );
+  } catch (e) {}
+
+  // 6. WebGL vendor & renderer — return realistic strings
+  try {
+    const getParam = WebGLRenderingContext.prototype.getParameter;
+    WebGLRenderingContext.prototype.getParameter = function (p) {
+      if (p === 37445) return 'Intel Inc.';                       // UNMASKED_VENDOR_WEBGL
+      if (p === 37446) return 'Intel Iris OpenGL Engine';         // UNMASKED_RENDERER_WEBGL
+      return getParam.call(this, p);
+    };
+  } catch (e) {}
+})();
+"""
+
+
+def apply_stealth(context) -> None:
+    """Attach the init script to a Playwright BrowserContext."""
+    try:
+        context.add_init_script(STEALTH_INIT_SCRIPT)
+    except Exception:
+        pass
+
+
+# --- Action helpers --------------------------------------------------------
+
+def human_sleep(low: float = 0.4, high: float = 1.2) -> None:
+    """Sleep a random fraction of a second. Use between user-facing actions."""
+    time.sleep(random.uniform(low, high))
+
+
+def human_type(selector_or_locator, text: str, *, base_delay_ms: int = 80) -> None:
+    """Type into a Playwright locator with variable per-char delay + occasional pauses.
+
+    Real humans don't type with a fixed 250ms cadence. Mean ~80ms, jitter ±50ms,
+    plus a 10% chance of a 200–500ms "think" pause between characters.
+    """
+    # Click first to focus, with a tiny pre-click pause.
+    try:
+        selector_or_locator.click()
+    except Exception:
+        pass
+    human_sleep(0.15, 0.4)
+
+    for ch in text:
+        delay = max(20, int(random.gauss(base_delay_ms, 35)))
+        try:
+            selector_or_locator.type(ch, delay=delay)
+        except Exception:
+            # Fallback: PressSequence via keyboard
+            try:
+                selector_or_locator.press(ch)
+            except Exception:
+                pass
+        # Occasional thinking pause
+        if random.random() < 0.10:
+            time.sleep(random.uniform(0.2, 0.5))
+
+
+def human_mouse_jitter(page, *, moves: int = 3) -> None:
+    """Wiggle the mouse to a few random points within the viewport."""
+    try:
+        vp = page.viewport_size or {"width": 1366, "height": 768}
+        for _ in range(moves):
+            x = random.randint(50, max(60, vp["width"] - 50))
+            y = random.randint(50, max(60, vp["height"] - 50))
+            page.mouse.move(x, y, steps=random.randint(8, 20))
+            time.sleep(random.uniform(0.05, 0.2))
+    except Exception:
+        pass
+
+
+def human_scroll(page, *, steps: int = None) -> None:
+    """Scroll the page like a human reading results."""
+    n = steps if steps is not None else random.randint(2, 5)
+    try:
+        for _ in range(n):
+            dy = random.randint(200, 700)
+            page.mouse.wheel(0, dy)
+            time.sleep(random.uniform(0.3, 1.1))
+        # Occasionally scroll back up a bit
+        if random.random() < 0.3:
+            page.mouse.wheel(0, -random.randint(100, 300))
+            time.sleep(random.uniform(0.2, 0.5))
+    except Exception:
+        pass

--- a/src/ai_marketplace_monitor/listing_scorer.py
+++ b/src/ai_marketplace_monitor/listing_scorer.py
@@ -1,0 +1,331 @@
+"""Advanced rule-based listing scorer for car flipping.
+
+Replaces AI evaluation with a fast, deterministic regex+keyword scorer.
+Designed to filter out time-wasters and surface profitable listings ASAP.
+
+Rejection levels (configurable per item via `rejection_level`):
+  - "firehose":   see everything that isn't a hard-reject       (threshold = -99)
+  - "lenient":    skip obvious junk                              (threshold = -3)
+  - "normal":     balanced — skip junk & most red flags          (threshold =  0)
+  - "strict":     only listings with at least 1 positive signal  (threshold =  3)
+  - "best_only":  only the cream of the crop                     (threshold =  6)
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+
+# === HARD REJECT PATTERNS ===
+# Any match here = instant reject, no scoring needed.
+# Order matters minimally — these are OR'd into one regex.
+HARD_REJECT_PATTERNS: Tuple[str, ...] = (
+    r"\bcash\s*for\s*cars?\b",
+    r"\bcar\s*removal\b",
+    r"\bfree\s*removal\b",
+    r"\bwe\s*buy\b",
+    r"\bbuying\s*cars?\b",
+    r"\bwrecking\b",
+    r"\bwreckers?\b",
+    r"\bscrap(?:ping)?\b",
+    r"\bdismantling\b",
+    r"\bparts\s*only\b",
+    r"\bcar\s*parts\b",
+    r"\bspares\s*or\s*repairs?\b",
+    r"\bswap(?:s|ping)?\b",
+    r"\bswap\s*(?:or|and|/)?\s*(?:trade|sell|deal)\b",
+    r"\bsell\s*(?:or|and|/)?\s*(?:swap|trade)\b",
+    r"\bopen\s*to\s*(?:swaps?|trades?)\b",
+    r"\btrade(?:s|d|in)?\s*(?:for|only|considered|welcome|in)\b",
+    r"\bfor\s*parts\b",
+    r"\bparts\s*cars?\b",
+    r"\bpart[-\s]?out\b",
+    r"\bblown\s*head\s*gasket\b",
+    r"\bhgs?\s*(?:gone|blown|leaking|leak)\b",        # "HG gone"
+    # --- Tyres / mags / wheels / rims sold as accessories (not whole cars) ---
+    r"\b(?:tyres?|tires?|mags?|wheels?|rims?|alloys?)\s+(?:and|&|\+)\s*(?:tyres?|tires?|mags?|wheels?|rims?|alloys?)\b",
+    r"\bset\s*of\s*(?:4\s*)?(?:tyres?|tires?|mags?|wheels?|rims?|alloys?)\b",
+    r"\b\d+\s*x?\s*(?:tyres?|tires?|mags?|rims?|alloys?)\b",   # "4 tyres", "4x mags"
+    r"\b(?:tyres?|tires?|mags?|wheels?|rims?|alloys?)\s+for\s+sale\b",
+    r"\bbrand\s*new\s*(?:tyres?|tires?|mags?|wheels?|rims?|alloys?)\b",
+    r"\b(?:tyres?|tires?|mags?|alloys?)\s+\d+x\d+\b",          # "tyres 215x60"
+    r"\b\d+\s*(?:inch|\"\s*)\s*(?:mags?|wheels?|rims?|alloys?)\b",   # "17 inch mags"
+    # --- Body kit / aero parts (not whole cars) ---
+    r"\blip\s*kits?\b",
+    r"\bbody\s*kits?\b",
+    r"\bspoilers?\b",
+    r"\b(?:fender|wheel|guard)\s*flares?\b",
+    r"\b\d+pcs?\s*flares?\b",                              # "4pc flares"
+    r"\bside\s*skirts?\b",
+    r"\bbumper\s+(?:lip|cover|kit|guard|spoiler)\b",
+    r"\bdiffuser\s*(?:kit|set)?\b",
+    r"\bcanards?\b",
+    r"\bwidebody\s*kits?\b",
+    # --- Turbocharger components / standalone turbo parts ---
+    r"\bturbocharger\b",                                   # the noun specifically
+    r"\bcompressor\s*wheel\b",
+    r"\bturbine\s*wheel\b",
+    r"\bbillet\s*(?:compressor|wheel|turbo)\b",
+    r"\bv[-\s]?band\s*(?:entry|exit|flange|clamp)\b",
+    r"\bT\s*\d\s*/\s*T\s*\d\b",                            # T3/T4 flange
+    r"\bexhaust\s*manifold\b",
+    r"\bintercoolers?\b",
+    r"\bdownpipes?\b",
+    r"\bwastegates?\b",
+    r"\b(?:blow[-\s]?off\s*valve|BOV)\b",
+    r"\bturbo\s*manifold\b",
+    r"\bexternal\s*wastegate\b",
+    # Turbo model numbers: G25-550, G30-660, GT3582, GTX3076, S366, EFR7163, K04, etc.
+    r"\bG\d{2,3}[-\s]?\d{3,4}\b",
+    r"\bGT[XR]?\d{3,5}\b",
+    r"\bS\d{3,4}(?:SXE|SXR|SX)?\b",
+    r"\bEFR\s*\d{4}\b",
+    r"\bK\d{2,3}\s*turbo\b",
+    r"\bHX\d{2,3}\b",                                       # Holset HX35 etc.
+    r"\bwanted\b",
+    r"\bwtb\b",                   # want to buy
+    r"\btowing\b",
+    r"\bblown\s*(?:engine|motor|head\s*gasket)\b",
+    r"\bhead\s*gasket\s*(?:gone|blown|leak)",
+    r"\bno\s*engine\b",
+    r"\bnon[-\s]*runner\b",
+    r"\bnot\s*running\b",
+    r"\b(?:won'?t|doesn'?t|wont|doesnt)\s*start\b",
+    r"\bneeds?\s*(?:engine|gearbox|transmission|new\s*motor)\b",
+    r"\bwritten\s*off\b",
+    r"\bwrite[-\s]*off\b",
+    r"\bsalvage\b",
+    r"\bdamaged\s*repairable\b",
+    r"\bauto\s*recycling\b",
+    r"\bproject\s*car\b",
+    r"\bdrift\s*car\b",
+    r"\brace\s*car\b",
+)
+
+_HARD_REJECT_RE = re.compile("|".join(HARD_REJECT_PATTERNS), re.IGNORECASE)
+
+
+# === NEGATIVE SIGNALS ===
+# (regex pattern, weight, label)
+NEGATIVE_SIGNALS: Tuple[Tuple[str, int, str], ...] = (
+    (r"\bno\s*wof\b",                   -3, "no WOF"),
+    (r"\bno\s*rego\b",                  -3, "no rego"),
+    (r"\b(?:wof|rego)\s*expired\b",     -2, "WOF/rego expired"),
+    (r"\bexpired\s*(?:wof|rego)\b",     -2, "expired WOF/rego"),
+    (r"\bderegistered\b",               -3, "deregistered"),
+    (r"\bas[-\s]?is\b",                 -2, "sold as-is"),
+    (r"\bneeds?\s*work\b",              -2, "needs work"),
+    (r"\bneeds?\s*tlc\b",               -2, "needs TLC"),
+    (r"\bmechanical\s*issues?\b",       -3, "mechanical issues"),
+    (r"\bengine\s*(?:light|warning)\b", -2, "engine light"),
+    (r"\bcheck\s*engine\b",             -2, "check engine"),
+    (r"\brusty\b",                      -2, "rust"),
+    (r"\brust\b",                       -1, "rust mention"),
+    (r"\bleaks?\b",                     -2, "leaks"),
+    (r"\bsmokes?\b",                    -3, "smokes"),
+    (r"\bburn(?:s|ing)?\s*oil\b",       -3, "burns oil"),
+    (r"\bhigh\s*km?s?\b",               -1, "high km"),
+    (r"\bhigh\s*mileage\b",             -1, "high mileage"),
+    (r"\bfirst\s*to\s*see\b",           -1, "pushy seller"),
+    (r"\bquick\s*sale\b",               -1, "quick sale (suspect)"),
+    (r"\burgent\b",                     -1, "urgent (suspect)"),
+    (r"\bmoving\s*(?:overseas|country|abroad)\b", -2, "moving overseas (scam pattern)"),
+    (r"\bno\s*offers?\b",               -1, "no offers (inflated)"),
+    (r"\bfirm\s*price\b",               -1, "firm price"),
+    (r"\bauction\b",                    -1, "auction"),
+    (r"\bcrashed?\b",                   -3, "crashed"),
+    (r"\baccident\b",                   -2, "accident"),
+    (r"\brolled\b",                     -3, "rolled"),
+    (r"\bflood(?:ed|\s*damage)?\b",     -3, "flood damaged"),
+    (r"\bmodified\b",                   -1, "modified"),
+    (r"\blowered\b",                    -1, "lowered"),
+    (r"\bturbo'?d\b",                   -1, "turbo'd"),
+    (r"\bdealer\b",                     -1, "dealer (often marked up)"),
+)
+
+# === POSITIVE SIGNALS ===
+POSITIVE_SIGNALS: Tuple[Tuple[str, int, str], ...] = (
+    (r"\bnew\s*wof\b",                   +3, "new WOF"),
+    (r"\bfresh\s*wof\b",                 +3, "fresh WOF"),
+    (r"\blong\s*wof\b",                  +2, "long WOF"),
+    (r"\bnew\s*rego\b",                  +2, "new rego"),
+    (r"\blong\s*rego\b",                 +2, "long rego"),
+    (r"\b(?:11|12)\s*months?\s*(?:wof|rego)\b", +2, "12 months WOF/rego"),
+    (r"\bnew\s*ty[re|ire]res?\b",        +1, "new tyres"),
+    (r"\bnew\s*battery\b",               +1, "new battery"),
+    (r"\b(?:just|recently)\s*serviced\b", +1, "just serviced"),
+    (r"\bfull\s*service\s*history\b",    +2, "full service history"),
+    (r"\bservice\s*history\b",           +1, "service history"),
+    (r"\b(?:one|1|single)\s*owner\b",    +2, "one owner"),
+    (r"\bnon[-\s]*smoker\b",             +1, "non-smoker"),
+    (r"\bgaraged\b",                     +1, "garaged"),
+    (r"\blow\s*km?s?\b",                 +2, "low km"),
+    (r"\blow\s*mileage\b",               +2, "low mileage"),
+    (r"\btidy\b",                        +1, "tidy"),
+    (r"\bimmaculate\b",                  +2, "immaculate"),
+    (r"\bexcellent\s*condition\b",       +1, "excellent condition"),
+    (r"\bgreat\s*condition\b",           +1, "great condition"),
+    (r"\bmint\s*condition\b",            +2, "mint condition"),
+    (r"\bnz[-\s]*new\b",                 +1, "NZ new"),
+    (r"\bbooks?\s*(?:and|&)\s*keys?\b",  +1, "books and keys"),
+    (r"\b2\s*keys?\b",                   +1, "2 keys"),
+    (r"\bregularly\s*serviced\b",        +1, "regularly serviced"),
+    (r"\bcambelt\s*(?:done|replaced)\b", +2, "cambelt done"),
+    (r"\btiming\s*belt\s*(?:done|replaced)\b", +2, "timing belt done"),
+)
+
+
+# Compile once
+_NEGATIVE_RES = [(re.compile(p, re.IGNORECASE), w, l) for p, w, l in NEGATIVE_SIGNALS]
+_POSITIVE_RES = [(re.compile(p, re.IGNORECASE), w, l) for p, w, l in POSITIVE_SIGNALS]
+
+
+# === KM / YEAR HEURISTICS ===
+_KM_RE = re.compile(
+    r"\b(\d{2,3}(?:[,.]?\d{3})?|\d+)\s*(?:k|kms?|kilom)\b", re.IGNORECASE
+)
+_YEAR_RE = re.compile(r"\b(19[89]\d|20[0-3]\d)\b")
+
+
+def _extract_km(text: str) -> int | None:
+    """Try to extract kilometres from text. Returns km as int or None."""
+    for match in _KM_RE.finditer(text):
+        raw = match.group(1).replace(",", "").replace(".", "")
+        unit_hint = match.group(0).lower()
+        try:
+            n = int(raw)
+        except ValueError:
+            continue
+        # "150k" -> 150000; "150000kms" -> 150000
+        if n < 1000 and ("k" in unit_hint and "km" not in unit_hint and "kilom" not in unit_hint):
+            n *= 1000
+        if 1000 <= n <= 1_000_000:
+            return n
+    return None
+
+
+def _extract_year(text: str) -> int | None:
+    """Extract first plausible vehicle year."""
+    match = _YEAR_RE.search(text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+# === REJECTION LEVELS ===
+THRESHOLDS = {
+    "firehose":  -99,
+    "lenient":   -3,
+    "normal":    0,
+    "strict":    3,
+    "best_only": 6,
+}
+
+
+@dataclass
+class ScoreResult:
+    score: int = 0
+    rejected: bool = False
+    hard_reject: bool = False
+    reasons: List[str] = field(default_factory=list)
+    km: int | None = None
+    year: int | None = None
+
+    @property
+    def summary(self) -> str:
+        if self.hard_reject:
+            return f"❌ HARD REJECT: {', '.join(self.reasons)}"
+        sign = "✅" if self.score >= 3 else ("⚠️" if self.score >= 0 else "❌")
+        bits = [f"{sign} Score: {self.score}"]
+        if self.km is not None:
+            bits.append(f"{self.km // 1000}k km")
+        if self.year is not None:
+            bits.append(f"{self.year}")
+        if self.reasons:
+            bits.append(" | ".join(self.reasons))
+        return " · ".join(bits)
+
+
+# Placeholder/junk prices that almost always indicate the seller didn't bother
+# entering a real price. $1,234 is the famous one (keyboard walk).
+PLACEHOLDER_PRICES = {1234.0, 12345.0, 1111.0, 9999.0, 11111.0, 99999.0}
+
+
+def is_placeholder_price(price_value: Optional[float]) -> bool:
+    return price_value is not None and price_value in PLACEHOLDER_PRICES
+
+
+def score_listing(
+    title: str,
+    description: str = "",
+    rejection_level: str = "normal",
+    price_value: Optional[float] = None,
+) -> ScoreResult:
+    """Score a listing. Higher = better. Hard rejects bypass scoring."""
+    text = f"{title or ''} {description or ''}"
+    result = ScoreResult()
+
+    # 0) Placeholder price = junk listing
+    if is_placeholder_price(price_value):
+        result.hard_reject = True
+        result.rejected = True
+        result.score = -99
+        result.reasons.append(f"hard:placeholder_price_${int(price_value)}")
+        return result
+
+    # 1) HARD REJECT — instant skip
+    hard = _HARD_REJECT_RE.search(text)
+    if hard:
+        result.hard_reject = True
+        result.rejected = True
+        result.score = -99
+        result.reasons.append(f"hard:{hard.group(0).lower()}")
+        return result
+
+    # 2) Negative signals
+    for regex, weight, label in _NEGATIVE_RES:
+        if regex.search(text):
+            result.score += weight
+            result.reasons.append(f"{weight:+d} {label}")
+
+    # 3) Positive signals
+    for regex, weight, label in _POSITIVE_RES:
+        if regex.search(text):
+            result.score += weight
+            result.reasons.append(f"{weight:+d} {label}")
+
+    # 4) KM-based penalties (only if extracted)
+    km = _extract_km(text)
+    if km is not None:
+        result.km = km
+        if km > 300_000:
+            result.score -= 4
+            result.reasons.append("-4 very high km (>300k)")
+        elif km > 250_000:
+            result.score -= 2
+            result.reasons.append("-2 high km (>250k)")
+        elif km < 100_000:
+            result.score += 2
+            result.reasons.append("+2 low km (<100k)")
+        elif km < 150_000:
+            result.score += 1
+            result.reasons.append("+1 moderate km (<150k)")
+
+    # 5) Year-based penalties
+    year = _extract_year(text)
+    if year is not None:
+        result.year = year
+        if year < 2000:
+            result.score -= 3
+            result.reasons.append("-3 very old (<2000)")
+        elif year < 2005:
+            result.score -= 1
+            result.reasons.append("-1 old (<2005)")
+        elif year >= 2015:
+            result.score += 1
+            result.reasons.append("+1 newer (2015+)")
+
+    # 6) Apply threshold
+    threshold = THRESHOLDS.get(rejection_level, THRESHOLDS["normal"])
+    result.rejected = result.score < threshold
+    return result

--- a/src/ai_marketplace_monitor/marketplace.py
+++ b/src/ai_marketplace_monitor/marketplace.py
@@ -404,6 +404,17 @@ class ItemConfig(MarketItemCommonConfig):
     antikeywords: List[str] | None = None
     description: str | None = None
     marketplace: str | None = None
+    # Algorithmic scorer threshold: firehose | lenient | normal | strict | best_only
+    rejection_level: str | None = None
+
+    def handle_rejection_level(self: "ItemConfig") -> None:
+        if self.rejection_level is None:
+            self.rejection_level = "normal"
+        allowed = {"firehose", "lenient", "normal", "strict", "best_only"}
+        if self.rejection_level not in allowed:
+            raise ValueError(
+                f"Item {hilight(self.name)} rejection_level must be one of {sorted(allowed)}."
+            )
 
     def handle_search_phrases(self: "ItemConfig") -> None:
         if isinstance(self.search_phrases, str):
@@ -513,13 +524,16 @@ class Marketplace(Generic[TMarketplaceConfig, TItemConfig]):
             self.page = None
 
         if self.page is None:
-            context = self.browser.new_context(
-                proxy=(
-                    None
-                    if self.config.monitor_config is None
-                    else self.config.monitor_config.get_proxy_options()
-                )
+            from .human_actions import apply_stealth, human_context_opts
+
+            ctx_kwargs = human_context_opts()
+            ctx_kwargs["proxy"] = (
+                None
+                if self.config.monitor_config is None
+                else self.config.monitor_config.get_proxy_options()
             )
+            context = self.browser.new_context(**ctx_kwargs)
+            apply_stealth(context)
             self.page = context.new_page()
         return self.page
 

--- a/src/ai_marketplace_monitor/monitor.py
+++ b/src/ai_marketplace_monitor/monitor.py
@@ -15,8 +15,13 @@ from rich.prompt import Prompt
 from .ai import AIBackend, AIResponse
 from .config import Config, supported_ai_backends, supported_marketplaces
 from .listing import Listing
+from .listing_scorer import score_listing
 from .marketplace import Marketplace, TItemConfig, TMarketplaceConfig
 from .notification import NotificationStatus
+from .analytics_db import parse_price, record_listing
+from .human_actions import HUMAN_LAUNCH_ARGS
+from .nzta_wof import check_wof, extract_plate_from_text, scan_wof_text, should_notify
+from .plate_ocr import detect_plates_from_listing
 from .user import User
 from .utils import (
     CounterItem,
@@ -105,7 +110,12 @@ class MarketplaceMonitor:
             try:
                 if self.logger:
                     self.logger.debug(f"Attempting to launch {browser_name} browser...")
-                browser = browser_type.launch(headless=self.headless)
+                launch_kwargs = {"headless": self.headless}
+                if browser_name == "chromium":
+                    # Anti-detection: strip the automation banner & a few headless tells.
+                    launch_kwargs["args"] = HUMAN_LAUNCH_ARGS
+                    launch_kwargs["ignore_default_args"] = ["--enable-automation"]
+                browser = browser_type.launch(**launch_kwargs)
                 if self.logger:
                     self.logger.info(
                         f"""{hilight("[Browser]", "info")} Successfully launched {browser_name} browser.""",
@@ -198,66 +208,163 @@ class MarketplaceMonitor:
                         ),
                     )
                 continue
-            # for x in self.find_new_items(found_items)
-            res = self.evaluate_by_ai(
-                listing, item_config=item_config, marketplace_config=marketplace_config
+            # === ALGORITHMIC SCORING (no AI, pure regex — microseconds) ===
+            rejection_level = getattr(item_config, "rejection_level", None) or "normal"
+            price_value, _ = parse_price(getattr(listing, "price", None))
+            score = score_listing(
+                listing.title or "",
+                getattr(listing, "description", "") or "",
+                rejection_level=rejection_level,
+                price_value=price_value,
             )
-            if self.logger:
-                if res.comment == AIResponse.NOT_EVALUATED:
-                    if res.name:
-                        self.logger.info(
-                            f"""{hilight("[AI]", res.style)} {res.name or "AI"} did not evaluate {hilight(listing.title)}."""
-                        )
-                    else:
-                        self.logger.info(
-                            f"""{hilight("[AI]", res.style)} No AI available to evaluate {hilight(listing.title)}."""
-                        )
-                else:
-                    self.logger.info(
-                        f"""{hilight("[AI]", res.style)} {res.name or "AI"} concludes {hilight(f"{res.conclusion} ({res.score}): {res.comment}", res.style)} for listing {hilight(listing.title)}.""",
-                        extra=aimm_event(
-                            "ai_eval",
-                            listing_id=listing.id,
-                            title=listing.title,
-                            url=getattr(listing, "post_url", None)
-                            or getattr(listing, "url", None),
-                            price=getattr(listing, "price", None),
-                            score=res.score,
-                            conclusion=res.conclusion,
-                            comment=res.comment,
-                            ai_name=res.name,
-                            item=item_config.name,
-                        ),
-                    )
-            if item_config.rating:
-                acceptable_rating = item_config.rating[
-                    0 if item_config.searched_count == 0 else -1
-                ]
-            elif marketplace_config.rating:
-                acceptable_rating = marketplace_config.rating[
-                    0 if item_config.searched_count == 0 else -1
-                ]
-            else:
-                acceptable_rating = 3
 
-            if res.score < acceptable_rating:
+            if score.rejected:
+                reason = "hard_reject" if score.hard_reject else "below_threshold"
                 if self.logger:
                     self.logger.info(
-                        f"""{hilight("[Skip]", "fail")} Rating {hilight(f"{res.conclusion} ({res.score})")} for {listing.title} is below threshold {acceptable_rating}.""",
+                        f"""{hilight("[Skip]", "fail")} {score.summary} — {hilight(listing.title)}""",
                         extra=aimm_event(
                             "listing_skip",
-                            reason="below_threshold",
+                            reason=reason,
                             listing_id=listing.id,
                             title=listing.title,
                             item=item_config.name,
-                            score=res.score,
-                            threshold=acceptable_rating,
+                            score=score.score,
+                            level=rejection_level,
                         ),
                     )
+                record_listing(
+                    listing=listing,
+                    item_name=item_config.name,
+                    score=score.score,
+                    rejection_level=rejection_level,
+                    notified=False,
+                    skip_reason=f"score:{reason}",
+                    logger=self.logger,
+                )
                 counter.increment(CounterItem.EXCLUDED_LISTING, item_config.name)
                 continue
+
+            # === PRE-NOTIFY VERIFICATION ===
+            # 1) Plate from text (title → description)
+            description = getattr(listing, "description", "") or ""
+            plate = extract_plate_from_text(listing.title) or extract_plate_from_text(description)
+            plate_source = "text" if plate else None
+
+            # 2) Plate from OCR over EVERY listing photo (not just thumbnail)
+            if not plate and self.browser:
+                try:
+                    plates = detect_plates_from_listing(
+                        listing.post_url, self.browser, logger=self.logger
+                    )
+                    if plates:
+                        plate = plates[0]
+                        plate_source = "ocr"
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    if self.logger:
+                        self.logger.debug(f"""{hilight("[PlateOCR]", "fail")} {e}""")
+
+            # 3) NZTA check (if plate found)
+            wof = None
+            if plate and self.browser:
+                if self.logger:
+                    self.logger.info(
+                        f"""{hilight("[Plate]", "info")} {plate} (via {plate_source}) — {hilight(listing.title)}"""
+                    )
+                wof = check_wof(plate, self.browser, self.logger)
+
+            # 4) Description-level WOF/rego claims (fallback signal)
+            text_claims = scan_wof_text(listing.title + " " + description)
+
+            # 5) Gate notification on WOF/rego rules
+            do_notify, reason = should_notify(wof, text_claims=text_claims)
+            if not do_notify:
+                if self.logger:
+                    self.logger.info(
+                        f"""{hilight("[Skip]", "fail")} WOF gate: {reason} — {hilight(listing.title)}""",
+                        extra=aimm_event(
+                            "listing_skip",
+                            reason="wof_gate",
+                            listing_id=listing.id,
+                            title=listing.title,
+                            item=item_config.name,
+                            wof_reason=reason,
+                        ),
+                    )
+                record_listing(
+                    listing=listing,
+                    item_name=item_config.name,
+                    score=score.score,
+                    rejection_level=rejection_level,
+                    plate=plate,
+                    plate_source=plate_source,
+                    wof=wof,
+                    notified=False,
+                    skip_reason=f"wof_gate:{reason}",
+                    logger=self.logger,
+                )
+                counter.increment(CounterItem.EXCLUDED_LISTING, item_config.name)
+                continue
+
+            # === NOTIFY (WOF/rego verified, or unverifiable but no red flags) ===
+            # Bake WOF/rego summary into the description so it travels with the
+            # main Telegram alert. Also log it prominently to stdout/cmd.
+            wof_block = ""
+            if wof:
+                src_note = f" · plate via {plate_source}" if plate else ""
+                wof_block = f"🔍 WOF/Rego{src_note}\n{wof.summary}\n"
+                if self.logger:
+                    self.logger.info(
+                        f"""{hilight("[WOF]", "succ")} {wof.summary.replace(chr(10), ' | ')}"""
+                    )
+            elif plate is None:
+                wof_block = "🔍 WOF/Rego: no plate found — couldn't verify\n"
+                if self.logger:
+                    self.logger.info(
+                        f"""{hilight("[WOF]", "info")} No plate found in text or images for {hilight(listing.title)}"""
+                    )
+
+            original_desc = getattr(listing, "description", "") or ""
+            if wof_block:
+                listing.description = wof_block + ("\n" + original_desc if original_desc else "")
+
+            res = AIResponse(score=0, comment=AIResponse.NOT_EVALUATED)
             new_listings.append(listing)
             listing_ratings.append(res)
+            counter.increment(CounterItem.NEW_VALIDATED_LISTING, item_config.name)
+            if self.logger:
+                self.logger.info(
+                    f"""{hilight("[Match]", "succ")} {score.summary} — {hilight(listing.title)} — {reason}""",
+                    extra=aimm_event(
+                        "listing_match",
+                        listing_id=listing.id,
+                        title=listing.title,
+                        item=item_config.name,
+                        score=score.score,
+                        level=rejection_level,
+                        wof_reason=reason,
+                        wof_status=wof.wof_status if wof else None,
+                        rego_status=wof.rego_status if wof else None,
+                    ),
+                )
+            for user in users_to_notify:
+                User(self.config.user[user], logger=self.logger).notify(
+                    [listing], [res], item_config
+                )
+            record_listing(
+                listing=listing,
+                item_name=item_config.name,
+                score=score.score,
+                rejection_level=rejection_level,
+                plate=plate,
+                plate_source=plate_source,
+                wof=wof,
+                notified=True,
+                skip_reason=None,
+                logger=self.logger,
+            )
 
         p = inflect.engine()
         if self.logger:
@@ -270,15 +377,6 @@ class MarketplaceMonitor:
                     new_count=len(new_listings),
                 ),
             )
-        if new_listings:
-            counter.increment(
-                CounterItem.NEW_VALIDATED_LISTING, item_config.name, len(new_listings)
-            )
-            for user in users_to_notify:
-                User(self.config.user[user], logger=self.logger).notify(
-                    new_listings, listing_ratings, item_config
-                )
-        time.sleep(5)
 
     def _select_translator(
         self: "MarketplaceMonitor", language: str | None = None

--- a/src/ai_marketplace_monitor/notification.py
+++ b/src/ai_marketplace_monitor/notification.py
@@ -91,6 +91,35 @@ class NotificationConfig(BaseConfig):
                 succ.append(subclass.notify_all(config, *args, **kwargs))
         return any(succ)
 
+    @classmethod
+    def notify_all_raw(
+        cls: type["NotificationConfig"],
+        config: "NotificationConfig",
+        message: str,
+        logger: Logger | None = None,
+    ) -> bool:
+        """Send a raw text message through all configured notification channels."""
+        succ = []
+        for subclass in cls.__subclasses__():
+            flds = {f.name for f in fields(subclass)}
+            try:
+                subclass_obj = subclass(**{k: getattr(config, k) for k in flds})
+            except Exception:
+                continue
+            if (
+                hasattr(subclass_obj, "send_message")
+                and subclass_obj._has_required_fields()
+                and subclass.__name__ not in ["UserConfig", "PushNotificationConfig"]
+            ):
+                try:
+                    succ.append(subclass_obj.send_message("🔍 WOF Check", message, logger))
+                except Exception as e:
+                    if logger:
+                        logger.debug(f"Raw message via {subclass.__name__} failed: {e}")
+            if hasattr(subclass, "notify_all_raw"):
+                succ.append(subclass.notify_all_raw(config, message, logger))
+        return any(succ)
+
     def _execute_with_retry(
         self: "NotificationConfig",
         title: str,

--- a/src/ai_marketplace_monitor/nzta_wof.py
+++ b/src/ai_marketplace_monitor/nzta_wof.py
@@ -1,0 +1,274 @@
+"""NZTA WOF/Rego expiry checker via transact.nzta.govt.nz.
+
+Drives the Blazor "Check expiry" form with Playwright and parses the result page.
+
+Confirmed page structure (from live capture):
+  - Form input:   <input id="plate" type="text" maxlength="6">
+  - Submit:       <button class="button-primary-1" type="submit">Continue</button>
+  - Results:
+      <table>
+        <tr><td>Plate number</td><td><strong>DYS664</strong></td></tr>
+        <tr><td>Vehicle details</td><td><strong>1996 TOYOTA CELICA</strong></td></tr>
+        <tr><td>Vehicle colour</td><td><strong>WHITE</strong></td></tr>
+      </table>
+      <dl><dt><b>Warrant of fitness expiry date</b></dt><dd>23 August 2026</dd></dl>
+      <dl><dt><b>Licence expiry date</b></dt><dd>25 August 2026</dd></dl>
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from logging import Logger
+from typing import Optional
+
+from playwright.sync_api import Browser, Page
+
+from .utils import hilight
+
+NZ_PLATE_PATTERN = re.compile(r"\b([A-Z]{2,3}\d{2,4})\b", re.IGNORECASE)
+NZTA_CHECK_URL = "https://transact.nzta.govt.nz/v2/Check-Expiry"
+
+
+@dataclass
+class WOFResult:
+    plate: str
+    vehicle: str             # "1996 TOYOTA CELICA"
+    colour: str              # "WHITE"
+    wof_expiry: str          # "23 August 2026"
+    rego_expiry: str         # "25 August 2026"
+    wof_status: str          # "Current" | "Expired" | "Unknown"
+    rego_status: str         # "Current" | "Expired" | "Unknown"
+    wof_days_remaining: Optional[int] = None
+    rego_days_remaining: Optional[int] = None
+
+    @property
+    def summary(self) -> str:
+        wof_icon = {"Current": "✅", "Expired": "❌"}.get(self.wof_status, "❓")
+        rego_icon = {"Current": "✅", "Expired": "❌"}.get(self.rego_status, "❓")
+        wof_extra = (
+            f" ({self.wof_days_remaining}d left)"
+            if self.wof_days_remaining is not None and self.wof_status == "Current"
+            else ""
+        )
+        rego_extra = (
+            f" ({self.rego_days_remaining}d left)"
+            if self.rego_days_remaining is not None and self.rego_status == "Current"
+            else ""
+        )
+        head = f"Plate: {self.plate}"
+        if self.vehicle:
+            head += f" — {self.vehicle}"
+        if self.colour:
+            head += f" ({self.colour.title()})"
+        return (
+            f"{head}\n"
+            f"{wof_icon} WOF: {self.wof_expiry}{wof_extra}\n"
+            f"{rego_icon} Rego: {self.rego_expiry}{rego_extra}"
+        )
+
+
+# --- Description-level WOF/rego text scanning ---------------------------
+
+_NO_WOF_RE = re.compile(r"\bno\s*(?:current\s*)?wof\b|\bwof\s*expired\b", re.I)
+_FRESH_WOF_RE = re.compile(
+    r"\b(?:new|fresh|full|long|just\s*passed)\s*wof\b"
+    r"|\bwof\s*(?:until|till|to|valid|good)\b"
+    r"|\b12\s*months?\s*wof\b",
+    re.I,
+)
+_NO_REGO_RE = re.compile(r"\bno\s*(?:current\s*)?rego\b|\brego\s*expired\b", re.I)
+_FRESH_REGO_RE = re.compile(
+    r"\b(?:new|fresh|full|long)\s*rego\b|\brego\s*(?:until|till|to|valid)\b"
+    r"|\b12\s*months?\s*rego\b",
+    re.I,
+)
+
+
+def scan_wof_text(text: str) -> dict:
+    """Look for seller-stated WOF/rego info in a title or description.
+
+    Returns dict with keys:
+      - wof_claim: 'fresh' | 'no' | None
+      - rego_claim: 'fresh' | 'no' | None
+    """
+    text = text or ""
+    return {
+        "wof_claim": "no" if _NO_WOF_RE.search(text) else ("fresh" if _FRESH_WOF_RE.search(text) else None),
+        "rego_claim": "no" if _NO_REGO_RE.search(text) else ("fresh" if _FRESH_REGO_RE.search(text) else None),
+    }
+
+
+# --- Notification gating --------------------------------------------------
+
+def should_notify(
+    wof: Optional[WOFResult],
+    text_claims: Optional[dict] = None,
+    min_wof_days: int = 30,
+    max_rego_days_overdue: int = 365,
+) -> tuple[bool, str]:
+    """Decide whether to push this listing to the phone.
+
+    Rules (per user spec):
+      - WOF expired                        → SKIP
+      - WOF expires in < min_wof_days days → SKIP
+      - Rego expired more than max_rego_days_overdue days → SKIP
+      - Anything else                       → NOTIFY
+
+    If we got NO data from NZTA (no plate / scrape failed), fall back to
+    seller-stated text claims: "no WOF" → SKIP, otherwise NOTIFY (we don't
+    have proof but the seller hasn't admitted to no WOF).
+    """
+    if wof is None:
+        if text_claims and text_claims.get("wof_claim") == "no":
+            return False, "seller stated: no WOF"
+        if text_claims and text_claims.get("rego_claim") == "no":
+            return False, "seller stated: no rego"
+        return True, "no plate / no NZTA data — notifying anyway"
+
+    # WOF gating
+    if wof.wof_status == "Expired":
+        return False, f"WOF expired ({wof.wof_expiry})"
+    if (
+        wof.wof_status == "Current"
+        and wof.wof_days_remaining is not None
+        and wof.wof_days_remaining < min_wof_days
+    ):
+        return False, f"WOF expires in {wof.wof_days_remaining} days (<{min_wof_days})"
+
+    # Rego gating — only block if very overdue
+    if (
+        wof.rego_status == "Expired"
+        and wof.rego_days_remaining is not None
+        and wof.rego_days_remaining < -max_rego_days_overdue
+    ):
+        return False, f"rego expired {-wof.rego_days_remaining} days ago"
+
+    return True, "WOF/rego OK"
+
+
+def extract_plate_from_text(text: str) -> Optional[str]:
+    """Try to find a NZ plate number in a listing title or description."""
+    if not text:
+        return None
+    match = NZ_PLATE_PATTERN.search(text.upper())
+    return match.group(1).upper() if match else None
+
+
+def _parse_date(date_str: str) -> Optional[datetime]:
+    """Parse '23 August 2026' style date."""
+    if not date_str:
+        return None
+    for fmt in ("%d %B %Y", "%d %b %Y"):
+        try:
+            return datetime.strptime(date_str.strip(), fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _status_from_date(date_str: str) -> tuple[str, Optional[int]]:
+    parsed = _parse_date(date_str)
+    if parsed is None:
+        return "Unknown", None
+    delta = (parsed - datetime.now()).days
+    return ("Current" if delta >= 0 else "Expired"), delta
+
+
+def _safe_inner_text(page: Page, selector: str) -> str:
+    try:
+        loc = page.locator(selector).first
+        loc.wait_for(state="attached", timeout=3000)
+        return (loc.inner_text() or "").strip()
+    except Exception:
+        return ""
+
+
+def check_wof(plate: str, browser: Browser, logger: Logger | None = None) -> Optional[WOFResult]:
+    """Submit the plate to NZTA Check-Expiry and parse the result."""
+    plate = (plate or "").strip().upper()
+    if not plate:
+        return None
+
+    page: Page | None = None
+    try:
+        page = browser.new_page()
+        page.set_default_timeout(20000)
+
+        if logger:
+            logger.info(f"{hilight('[WOF]', 'info')} Checking plate {hilight(plate)}...")
+
+        page.goto(NZTA_CHECK_URL, wait_until="networkidle")
+
+        # Wait for the Blazor form to mount
+        page.wait_for_selector("#plate", state="visible", timeout=15000)
+        page.fill("#plate", plate)
+
+        # Click the "Continue" submit button
+        page.locator('button[type="submit"]:has-text("Continue")').first.click()
+
+        # Wait for the SPA to swap in the results section (no navigation)
+        page.wait_for_selector('h3:has-text("Expiry details")', timeout=20000)
+        page.wait_for_selector(
+            'dt:has-text("Warrant of fitness expiry date")', timeout=10000
+        )
+
+        # ---- Parse table rows by label ----
+        vehicle = _safe_inner_text(
+            page, 'xpath=//td[contains(., "Vehicle details")]/following-sibling::td[1]'
+        )
+        colour = _safe_inner_text(
+            page, 'xpath=//td[contains(., "Vehicle colour")]/following-sibling::td[1]'
+        )
+
+        # ---- Parse <dl> sections ----
+        wof_expiry = _safe_inner_text(
+            page,
+            'xpath=//dt[contains(., "Warrant of fitness expiry date")]/following-sibling::dd[1]',
+        )
+        rego_expiry = _safe_inner_text(
+            page,
+            'xpath=//dt[contains(., "Licence expiry date")]/following-sibling::dd[1]',
+        )
+
+        wof_status, wof_days = _status_from_date(wof_expiry)
+        rego_status, rego_days = _status_from_date(rego_expiry)
+
+        # Fallback: if dates didn't parse, look for inline "expired" phrases
+        body_text = ""
+        try:
+            body_text = page.inner_text("#nzta-main-content")
+        except Exception:
+            pass
+        if wof_status == "Unknown" and re.search(r"warrant.*expired", body_text, re.I):
+            wof_status = "Expired"
+        if rego_status == "Unknown" and re.search(r"licence.*expired", body_text, re.I):
+            rego_status = "Expired"
+
+        result = WOFResult(
+            plate=plate,
+            vehicle=vehicle,
+            colour=colour,
+            wof_expiry=wof_expiry or "Unknown",
+            rego_expiry=rego_expiry or "Unknown",
+            wof_status=wof_status,
+            rego_status=rego_status,
+            wof_days_remaining=wof_days,
+            rego_days_remaining=rego_days,
+        )
+
+        if logger:
+            logger.info(f"{hilight('[WOF]', 'succ')} {result.summary}")
+        return result
+
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        if logger:
+            logger.error(f"{hilight('[WOF]', 'fail')} Failed to check plate {plate}: {e}")
+        return None
+    finally:
+        if page:
+            try:
+                page.close()
+            except Exception:
+                pass

--- a/src/ai_marketplace_monitor/plate_ocr.py
+++ b/src/ai_marketplace_monitor/plate_ocr.py
@@ -1,0 +1,361 @@
+"""Detect & OCR license plates from listing images.
+
+Pipeline:
+  1. open-image-models  → YOLO v9 ONNX plate detector  (returns bounding boxes)
+  2. fast-plate-ocr     → CCT ONNX plate recogniser   (reads text from each crop)
+
+Both run on CPU via onnxruntime (typically 50–150 ms / image after warm-up).
+Models are auto-downloaded on first use into the user-cache dir; subsequent runs
+load from disk. No GPU / no internet needed after the first run.
+
+Install:
+    pip install fast-plate-ocr open-image-models pillow numpy
+
+Pre-warm:
+    python -m ai_marketplace_monitor.plate_ocr --warmup
+"""
+
+import io
+import os
+import pathlib
+import re
+import urllib.request
+from logging import Logger
+from typing import List, Optional
+
+# Heavy deps are lazy-imported so the rest of the app starts fast.
+_detector = None
+_recognizer = None
+
+# NZ plate sanity filter: 2–3 letters + 2–4 digits.
+_NZ_PLATE_RE = re.compile(r"^[A-Z]{2,3}\d{2,4}$")
+
+# Defaults — the BIGGEST available ONNX models from each library.
+#   Detector: yolo-v9-s (small, 27MB) at 608px input — much better recall on
+#             small/angled plates than the t-384 tiny variant.
+#   OCR:      global-plates-mobile-vit-v2 (4.8MB) — newer MobileViT v2 arch,
+#             stronger than the CCT-XS we used initially.
+DEFAULT_DETECTION_MODEL = "yolo-v9-s-608-license-plate-end2end"
+DEFAULT_RECOGNIZER_MODEL = "global-plates-mobile-vit-v2-model"
+
+# Lower the detector confidence threshold so we catch small plates in
+# distant/angled shots. The OCR step + NZ-format regex filter out garbage.
+DEFAULT_DETECTOR_CONF = 0.15
+
+# Project-local model directory — checked in alongside the code so we don't
+# depend on a hidden ~/.cache directory the user can't see.
+# Override via AIMM_MODELS_DIR env var.
+_PKG_ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODELS_DIR = pathlib.Path(os.environ.get("AIMM_MODELS_DIR") or (_PKG_ROOT / "models"))
+
+DETECTOR_ONNX = MODELS_DIR / "yolo-v9-s-608-license-plates-end2end.onnx"
+RECOGNIZER_ONNX = MODELS_DIR / "global_mobile_vit_v2_ocr.onnx"
+RECOGNIZER_CONFIG = MODELS_DIR / "global_mobile_vit_v2_ocr_config.yaml"
+
+
+def _ensure_models(logger: Logger | None = None):
+    global _detector, _recognizer
+    if _detector is not None and _recognizer is not None:
+        return _detector, _recognizer
+    try:
+        from fast_plate_ocr import LicensePlateRecognizer  # type: ignore
+        from open_image_models import LicensePlateDetector  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "Plate OCR deps missing. Install with:\n"
+            "    pip install fast-plate-ocr open-image-models pillow numpy"
+        ) from e
+
+    if logger:
+        logger.info(f"[PlateOCR] Loading models from {MODELS_DIR}...")
+
+    # --- Recognizer: native path support ---
+    if RECOGNIZER_ONNX.is_file() and RECOGNIZER_CONFIG.is_file():
+        _recognizer = LicensePlateRecognizer(
+            onnx_model_path=str(RECOGNIZER_ONNX),
+            plate_config_path=str(RECOGNIZER_CONFIG),
+        )
+    else:
+        if logger:
+            logger.warning(
+                f"[PlateOCR] Recognizer ONNX missing at {RECOGNIZER_ONNX}, "
+                "falling back to hub download."
+            )
+        _recognizer = LicensePlateRecognizer(DEFAULT_RECOGNIZER_MODEL)
+
+    # --- Detector: no path arg, so monkey-patch download_model to return the
+    # local file. open-image-models' download_model just no-ops if the file
+    # already exists, so this is safe and idempotent.
+    if DETECTOR_ONNX.is_file():
+        try:
+            from open_image_models.detection.pipeline import license_plate as _lp_mod  # type: ignore
+            _original_dl = _lp_mod.download_model
+            def _local_download(name, *a, **kw):
+                if str(name) == DEFAULT_DETECTION_MODEL:
+                    return DETECTOR_ONNX
+                return _original_dl(name, *a, **kw)
+            _lp_mod.download_model = _local_download
+        except Exception as e:
+            if logger:
+                logger.debug(f"[PlateOCR] Could not patch detector loader: {e}")
+    elif logger:
+        logger.warning(
+            f"[PlateOCR] Detector ONNX missing at {DETECTOR_ONNX}, "
+            "falling back to hub download."
+        )
+
+    _detector = LicensePlateDetector(
+        detection_model=DEFAULT_DETECTION_MODEL,
+        conf_thresh=DEFAULT_DETECTOR_CONF,
+    )
+
+    if logger:
+        logger.info("[PlateOCR] Models ready.")
+    return _detector, _recognizer
+
+
+def _load_image_bytes_to_np(image_bytes: bytes):
+    import numpy as np  # type: ignore
+    from PIL import Image  # type: ignore
+
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    return np.array(img)
+
+
+def _bbox_xyxy(det) -> Optional[tuple[int, int, int, int]]:
+    """Normalise bbox across open-image-models versions."""
+    bb = getattr(det, "bounding_box", None) or getattr(det, "bbox", None)
+    if bb is None:
+        return None
+    if hasattr(bb, "x1"):
+        return int(bb.x1), int(bb.y1), int(bb.x2), int(bb.y2)
+    try:
+        x1, y1, x2, y2 = bb
+        return int(x1), int(y1), int(x2), int(y2)
+    except Exception:
+        return None
+
+
+def detect_plates_from_image(
+    image_bytes: bytes, logger: Logger | None = None, nz_only: bool = True
+) -> List[str]:
+    """Detect plates in an image. Returns plate strings (filtered to NZ-format by default)."""
+    try:
+        detector, recognizer = _ensure_models(logger)
+    except RuntimeError as e:
+        if logger:
+            logger.debug(f"[PlateOCR] {e}")
+        return []
+
+    try:
+        img = _load_image_bytes_to_np(image_bytes)
+    except Exception as e:
+        if logger:
+            logger.debug(f"[PlateOCR] Image decode failed: {e}")
+        return []
+
+    plates: List[str] = []
+    raw_reads: List[str] = []
+    try:
+        detections = detector.predict(img)
+    except Exception as e:
+        if logger:
+            logger.debug(f"[PlateOCR] Detector error: {e}")
+        return []
+
+    if logger:
+        h, w = img.shape[:2]
+        logger.info(f"[PlateOCR] Image {w}x{h} → {len(detections)} detection(s)")
+
+    for det in detections:
+        bbox = _bbox_xyxy(det)
+        if bbox is None:
+            continue
+        x1, y1, x2, y2 = bbox
+        h, w = img.shape[:2]
+        x1, y1 = max(0, x1), max(0, y1)
+        x2, y2 = min(w, x2), min(h, y2)
+        if x2 <= x1 or y2 <= y1:
+            continue
+        crop = img[y1:y2, x1:x2]
+        # fast-plate-ocr's global ViT model expects a 1-channel (grayscale) input.
+        # Our img is RGB (H, W, 3), so collapse to luminance.
+        try:
+            import numpy as np  # type: ignore
+            if crop.ndim == 3 and crop.shape[2] == 3:
+                # Rec.601 luminance weights — cheap and matches typical OCR preprocessing.
+                crop_gray = (
+                    0.299 * crop[..., 0] + 0.587 * crop[..., 1] + 0.114 * crop[..., 2]
+                ).astype(np.uint8)
+            else:
+                crop_gray = crop
+        except Exception:
+            crop_gray = crop
+
+        try:
+            result = recognizer.run(crop_gray)
+        except Exception as e:
+            if logger:
+                logger.warning(f"[PlateOCR] Recognizer error: {e}")
+            continue
+
+        # fast-plate-ocr returns list[PlatePrediction] — extract .plate string.
+        text = ""
+        if isinstance(result, (list, tuple)) and result:
+            first = result[0]
+            text = getattr(first, "plate", None) or str(first)
+        elif result is not None:
+            text = getattr(result, "plate", None) or str(result)
+
+        cleaned = re.sub(r"[^A-Za-z0-9]", "", text).upper()
+        if not cleaned:
+            if logger:
+                logger.info(f"[PlateOCR] OCR returned empty text for a {x2-x1}x{y2-y1} crop")
+            continue
+        raw_reads.append(cleaned)
+        if nz_only and not _NZ_PLATE_RE.match(cleaned):
+            if logger:
+                logger.info(f"[PlateOCR] Read '{cleaned}' — not NZ format, skipping")
+            continue
+        if logger:
+            logger.info(f"[PlateOCR] Read '{cleaned}' ✓")
+        plates.append(cleaned)
+
+    # De-dupe while preserving order
+    seen, unique = set(), []
+    for p in plates:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+
+    if logger:
+        if unique:
+            logger.info(f"[PlateOCR] Detected (NZ format): {unique}")
+        elif raw_reads:
+            logger.info(f"[PlateOCR] Read text but no NZ-format match: {raw_reads}")
+    return unique
+
+
+def detect_plates_from_url(
+    url: str, logger: Logger | None = None, nz_only: bool = True, timeout: float = 10.0
+) -> List[str]:
+    """Download an image URL and run plate detection on it."""
+    if not url:
+        return []
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+                )
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            data = r.read()
+    except Exception as e:
+        if logger:
+            logger.debug(f"[PlateOCR] Failed to fetch {url}: {e}")
+        return []
+    return detect_plates_from_image(data, logger=logger, nz_only=nz_only)
+
+
+def fetch_listing_photos(post_url: str, browser, logger=None, max_photos: int = 12) -> list[str]:
+    """Open a Facebook Marketplace listing URL and pull every product photo URL.
+
+    Facebook tags listing photos with `alt="Product photo of <title>"`.
+    Both the main image and every thumbnail use the same alt pattern, so a
+    single CSS selector covers the gallery.
+    """
+    if not post_url or not browser:
+        return []
+    page = None
+    try:
+        page = browser.new_page()
+        page.set_default_timeout(20000)
+        page.goto(post_url, wait_until="domcontentloaded", timeout=20000)
+        try:
+            page.wait_for_selector('img[alt^="Product photo"]', timeout=10000)
+        except Exception:
+            # Fallback: any img inside the listing viewer dialog
+            page.wait_for_selector(
+                'div[aria-label="Marketplace listing viewer"] img', timeout=10000
+            )
+        # Let lazy-loaded thumbnails populate
+        page.wait_for_timeout(900)
+        # Deduplicate src URLs, preserve order.
+        urls = page.eval_on_selector_all(
+            'img[alt^="Product photo"], div[aria-label="Marketplace listing viewer"] img',
+            "els => Array.from(new Set(els.map(e => e.currentSrc || e.src).filter(Boolean)))",
+        )
+        # Filter out obvious non-photo assets (profile pics, sponsored ads).
+        urls = [u for u in urls if "fbcdn" in u and "static_map" not in u]
+        if logger:
+            logger.info(f"[PlateOCR] Fetched {len(urls)} photos from listing.")
+        return urls[:max_photos]
+    except Exception as e:
+        if logger:
+            logger.debug(f"[PlateOCR] fetch_listing_photos failed: {e}")
+        return []
+    finally:
+        if page:
+            try:
+                page.close()
+            except Exception:
+                pass
+
+
+def detect_plates_from_listing(
+    post_url: str, browser, logger=None, nz_only: bool = True, max_photos: int = 12
+) -> list[str]:
+    """Visit a listing page, pull every product photo, OCR them all.
+
+    Returns the de-duplicated list of plates found across all images, in the
+    order they appeared (so the first plate is from the hero image).
+    """
+    photos = fetch_listing_photos(post_url, browser, logger=logger, max_photos=max_photos)
+    all_plates: list[str] = []
+    seen = set()
+    for i, url in enumerate(photos):
+        plates = detect_plates_from_url(url, logger=logger, nz_only=nz_only)
+        for p in plates:
+            if p not in seen:
+                seen.add(p)
+                all_plates.append(p)
+        if all_plates:
+            if logger:
+                logger.info(
+                    f"[PlateOCR] Found plate(s) after {i + 1}/{len(photos)} photos: {all_plates}"
+                )
+            # Early-exit: we have a plate, no need to OCR the rest
+            break
+    return all_plates
+
+
+if __name__ == "__main__":
+    import argparse
+    import logging
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    log = logging.getLogger("plate_ocr")
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--warmup", action="store_true", help="Download & load models, then exit.")
+    p.add_argument("--url", help="Run OCR on an image URL.")
+    p.add_argument("--file", help="Run OCR on a local image path.")
+    p.add_argument("--no-nz-filter", action="store_true")
+    args = p.parse_args()
+
+    if args.warmup:
+        _ensure_models(log)
+        print("Models ready.")
+        sys.exit(0)
+    if args.url:
+        print(detect_plates_from_url(args.url, logger=log, nz_only=not args.no_nz_filter))
+    elif args.file:
+        with open(args.file, "rb") as f:
+            print(detect_plates_from_image(f.read(), logger=log, nz_only=not args.no_nz_filter))
+    else:
+        p.print_help()

--- a/src/ai_marketplace_monitor/user.py
+++ b/src/ai_marketplace_monitor/user.py
@@ -192,3 +192,15 @@ class User:
             for listing, ns in zip(listings, statuses):
                 if force or ns != NotificationStatus.NOTIFIED:
                     self.to_cache(listing, local_cache=local_cache)
+
+    def send_raw_message(self: "User", message: str) -> None:
+        """Send a raw text message via all configured notification channels."""
+        try:
+            NotificationConfig.notify_all_raw(self.config, message, logger=self.logger)
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            if self.logger:
+                self.logger.error(
+                    f"""{hilight("[Notify]", "fail")} Failed to send raw message: {e}"""
+                )

--- a/src/ai_marketplace_monitor/utils.py
+++ b/src/ai_marketplace_monitor/utils.py
@@ -77,6 +77,7 @@ class CacheType(Enum):
     AI_INQUIRY = "ai-inquiries"
     USER_NOTIFIED = "user-notifications"
     COUNTERS = "counters"
+    SEEN_LISTINGS = "seen-listings"
 
 
 class CounterItem(Enum):


### PR DESCRIPTION
## Summary

Optimises the monitor for fast Facebook Marketplace **car flipping**, where speed-to-contact beats everything. Replaces the blocking AI evaluation with a deterministic rule-based scorer and adds plate/WOF verification as a notification gate.

- **`listing_scorer.py`** — regex/keyword scorer with 5 configurable rejection levels (`firehose` → `best_only`, set via `rejection_level` in item config). Hard-rejects parts/wreckers, swap-or-trade, tyres/mags/aero kits, standalone turbo gear + turbo model numbers (e.g. `G30-660`, `GT3582`), and placeholder prices ($1,234 etc.).
- **`plate_ocr.py`** — `open-image-models` YOLOv9-s detector + `fast-plate-ocr` MobileViT-v2 recogniser (ONNX/CPU). OCRs **every** listing photo (navigates to the listing URL via `alt="Product photo of …"`), not just the thumbnail. Loads models from `<repo>/models/` with hub-download fallback.
- **`nzta_wof.py`** — rewritten against the real `transact.nzta.govt.nz` Blazor form/result DOM. Parses vehicle/colour/WOF/rego expiry, computes days-remaining, and gates notifications: skip if no WOF, WOF < 30 days, or rego > 365 days overdue.
- **`analytics_db.py`** — SQLite store of every listing examined (numeric price, plate, WOF/rego, outcome + skip reason) for offline analysis.
- **`human_actions.py`** — stealth browser context + human-like typing/mouse/scroll to reduce Facebook captcha frequency; wired into login & search.
- **`monitor.py`** — restructured `search_item`: score → verify (plate → OCR → NZTA) → gate → instant Telegram with WOF baked into the alert.
- **`facebook.py`** — crash-safe per-item persisted seen-listing IDs, fast aria-label search parse, humanised login/search.
- **`ai.py`** — detect `sk-ant-oat` OAuth tokens (use `auth_token` vs `api_key`).

## Notes for reviewers

- This is opinionated toward NZ used-car flipping (NZTA WOF/rego, NZ plate regex `^[A-Z]{2,3}\d{2,4}$`). The scorer and gating are config-light by design — most behaviour is controlled by `rejection_level`.
- ONNX model binaries (~43 MB) and the runtime SQLite DB are **gitignored**; `plate_ocr.py` auto-downloads models on first run, or `scripts/warmup-plate-ocr.bat` pre-fetches them.
- New runtime deps for the plate feature: `fast-plate-ocr[onnx]`, `open-image-models`, `onnxruntime`, `pillow`, `numpy`. The feature degrades gracefully (logs + skips) if they're absent.
- AI evaluation path is removed from the hot loop; `AIResponse` is still used as a notification carrier (`NOT_EVALUATED`) so the existing notification formatting is unchanged.

## Test plan

- [ ] `aimm` runs a Facebook search cycle and pushes a matching listing to Telegram
- [ ] Junk (parts/swap/tyres/turbo/$1,234) is rejected and logged with `[Skip]`
- [ ] Plate found via text and via image OCR; NZTA WOF lookup succeeds
- [ ] WOF gate skips no-WOF / soon-to-expire listings
- [ ] `data/analytics.sqlite` accrues rows with correct outcome/skip_reason
- [ ] Existing diskcache (`SEEN_LISTINGS`, `USER_NOTIFIED`) behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added license plate detection from listing images using OCR.
  * Added NZTA WOF and vehicle registration status checking.
  * Added marketplace listing analytics and tracking database.
  * Introduced configurable listing rejection levels for refined filtering.

* **Bug Fixes**
  * Fixed Anthropic API authentication handling for different token formats.

* **Chores**
  * Updated `.gitignore` for model binaries and database files.
  * Added Python 3.13 warmup script for model initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoPeng/ai-marketplace-monitor/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->