### PR TITLE
Add Google Gemini AI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ AI: Great deal; A well-priced, well-maintained camera meets all search criteria,
 ## What's New
 
 - **Built-in Web UI**: Edit config, add AI backends, and monitor live logs from your browser — starts automatically with the monitor. See [Web UI documentation](docs/webui.md).
-- **Anthropic/Claude AI Backend**: Use Claude models (e.g. `claude-sonnet-4-20250514`) to evaluate listings alongside OpenAI, DeepSeek, and Ollama. See [AI Services](docs/README.md#ai-services) for configuration.
+- **Anthropic/Claude AI Backend**: Use Claude models (e.g. `claude-sonnet-4-20250514`) to evaluate listings alongside OpenAI, DeepSeek, Gemini, and Ollama. See [AI Services](docs/README.md#ai-services) for configuration.
 - **Configurable Rate Limiting**: Rate limiting framework for all notification types with per-instance and global limits. Telegram notifications use optimized defaults automatically.
 
 **Table of Contents:**
@@ -202,7 +202,7 @@ For detailed information on setup and advanced features, see the comprehensive d
 
 **AI Integration:**
 
-- OpenAI, DeepSeek, Anthropic, Ollama setup
+- OpenAI, DeepSeek, Gemini, Anthropic, Ollama setup
 - Custom prompt configuration
 - Rating thresholds and filtering
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,12 +47,13 @@ One of more sections to list the AI agent that can be used to judge if listings 
 Note that:
 
 1. `provider` can be [OpenAI](https://openai.com/),
-   [DeepSeek](https://www.deepseek.com/), [Anthropic](https://www.anthropic.com/), or [Ollama](https://ollama.com/). The name of the ai service will be used if this option is not specified so `OpenAI` will be used for section `ai.openai`.
-2. [OpenAI](https://openai.com/) and [DeepSeek](https://www.deepseek.com/) models sets default `base_url` and `model` for these providers.
+   [DeepSeek](https://www.deepseek.com/), [Gemini](https://ai.google.dev/), [Anthropic](https://www.anthropic.com/), or [Ollama](https://ollama.com/). The name of the ai service will be used if this option is not specified so `OpenAI` will be used for section `ai.openai`.
+2. [OpenAI](https://openai.com/), [DeepSeek](https://www.deepseek.com/), and [Gemini](https://ai.google.dev/) models sets default `base_url` and `model` for these providers.
 3. [Anthropic](https://www.anthropic.com/) uses the Anthropic SDK directly (not OpenAI-compatible). The default model is `claude-sonnet-4-20250514`. An `api_key` is required.
-4. Ollama models require `base_url`. A default model is set to `deepseek-r1:14b`, which seems to be good enough for this application. You can of course try [other models](https://ollama.com/library) by setting the `model` option.
-5. Although only four providers are directly supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api_key`.
-6. You can use option `ai` to list the AI services for particular marketplaces or items.
+4. [Gemini](https://ai.google.dev/) is accessed through Google's OpenAI-compatible endpoint. The default model is `gemini-2.5-flash`. An `api_key` is required and can be obtained from [Google AI Studio](https://aistudio.google.com/apikey).
+5. Ollama models require `base_url`. A default model is set to `deepseek-r1:14b`, which seems to be good enough for this application. You can of course try [other models](https://ollama.com/library) by setting the `model` option.
+6. Although only five providers are directly supported, you can use any other service provider with `OpenAI`-compatible API using customized `base_url`, `model`, and `api_key`.
+7. You can use option `ai` to list the AI services for particular marketplaces or items.
 
 A typical section for OpenAI looks like
 
@@ -66,6 +67,13 @@ A typical section for Anthropic looks like
 ```toml
 [ai.anthropic]
 api_key = 'sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+```
+
+A typical section for Gemini looks like
+
+```toml
+[ai.gemini]
+api_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 ```
 
 ### Marketplaces

--- a/src/ai_marketplace_monitor/ai.py
+++ b/src/ai_marketplace_monitor/ai.py
@@ -17,6 +17,7 @@ from .utils import BaseConfig, CacheType, CounterItem, cache, counter, hilight
 class AIServiceProvider(Enum):
     OPENAI = "OpenAI"
     DEEPSEEK = "DeepSeek"
+    GEMINI = "Gemini"
     ANTHROPIC = "Anthropic"
     OLLAMA = "Ollama"
 
@@ -133,6 +134,11 @@ class OpenAIConfig(AIConfig):
 
 @dataclass
 class DeekSeekConfig(OpenAIConfig):
+    pass
+
+
+@dataclass
+class GeminiConfig(OpenAIConfig):
     pass
 
 
@@ -366,6 +372,17 @@ class DeepSeekBackend(OpenAIBackend):
     @classmethod
     def get_config(cls: Type["DeepSeekBackend"], **kwargs: Any) -> DeekSeekConfig:
         return DeekSeekConfig(**kwargs)
+
+
+class GeminiBackend(OpenAIBackend):
+    """Google Gemini via its OpenAI-compatible endpoint."""
+
+    default_model = "gemini-2.5-flash"
+    base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+    @classmethod
+    def get_config(cls: Type["GeminiBackend"], **kwargs: Any) -> GeminiConfig:
+        return GeminiConfig(**kwargs)
 
 
 class OllamaBackend(OpenAIBackend):

--- a/src/ai_marketplace_monitor/config.py
+++ b/src/ai_marketplace_monitor/config.py
@@ -11,7 +11,14 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from .ai import AnthropicBackend, DeepSeekBackend, OllamaBackend, OpenAIBackend, TAIConfig
+from .ai import (
+    AnthropicBackend,
+    DeepSeekBackend,
+    GeminiBackend,
+    OllamaBackend,
+    OpenAIBackend,
+    TAIConfig,
+)
 from .facebook import FacebookMarketplace
 from .marketplace import TItemConfig, TMarketplaceConfig
 from .notification import NotificationConfig
@@ -22,6 +29,7 @@ from .utils import MonitorConfig, Translator, hilight, merge_dicts
 supported_marketplaces = {"facebook": FacebookMarketplace}
 supported_ai_backends = {
     "deepseek": DeepSeekBackend,
+    "gemini": GeminiBackend,
     "openai": OpenAIBackend,
     "anthropic": AnthropicBackend,
     "ollama": OllamaBackend,


### PR DESCRIPTION
## Summary

Adds first-class support for Google Gemini as an AI backend, so users can write

```toml
[ai.gemini]
api_key = 'xxxx'
```

instead of manually pointing an `[ai.xxx]` section with `provider = 'openai'` at Google's endpoint.

## Implementation

- `GeminiBackend(OpenAIBackend)` using Google's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`), following the same pattern as `DeepSeekBackend`
- Default model: `gemini-2.5-flash`
- `Gemini` added to `AIServiceProvider`, `GeminiConfig` added, and `gemini` registered in `supported_ai_backends`
- Documented the provider and a sample `[ai.gemini]` section in `README.md` and `docs/README.md`

Tested end-to-end with a real Gemini API key: listings are evaluated and scored correctly through the standard OpenAI-compatible chat completions flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini as a supported AI provider.
  * Gemini can now be selected through the app’s AI configuration and uses its own recommended settings.

* **Documentation**
  * Updated the main README and configuration docs to include Gemini in supported AI options.
  * Added a Gemini example configuration and clarified default setup behavior for AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->