### PR TITLE
feat: add sort_by option for Facebook search results (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Option `sort_by` to order Facebook search results by `suggested`, `new` (newest first), `price_ascend`, `price_descend`, or `distance_ascend` ([#323](https://github.com/BoPeng/ai-marketplace-monitor/issues/323))
+
 ## [0.10.2]
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -296,6 +296,7 @@ The following options that can specified for both `marketplace` sections and `it
 | `search_interval`     | Optional          | String              | Minimal interval between searches, should be specified in formats such as `1d`, `5h`, or `1h 30m`.                                                          |
 | `search_region`       | Optional          | String/List         | Search over multiple locations to cover an entire region. `regions` should be one or more pre-defined regions or regions defined in the configuration file. |
 | `seller_locations`    | Optional          | String/List         | Only allow searched items from these locations.                                                                                                             |
+| `sort_by`             | Optional          | String              | Order of search results. One of `suggested`, `new`, `price_ascend`, `price_descend`, and `distance_ascend`.                                                 |
 | `start_at`            | Optional          | String/List         | Time to start the search. Overrides `search_interval`.                                                                                                      |
 
 Note that
@@ -307,6 +308,7 @@ Note that
 5. A list of two values can be specified for options `rating`, `availability`, `delivery_method`, and `date_listed`. See [First and subsequent searches](../README.md#first-and-subsequent-searches) for details.
 6. `min_price` and `max_price` can be specified as a number (e.g. `min_price=100`) or a number followed by a currency name (e.g. `min_price='100 USD'`). If different currencies are specified for both `min_price/max_price` and `search_city` (or `region`), the `min_price` and `max_price` will be adjusted to use currency for the `search_city`. See [Searching across regions with different currencies](../README.md#searching-across-regions-with-different-currencies) for details.
 7. `category` can be `vehicles`, `propertyrentals`, `apparel`, `electronics`, `entertainment`, `family`, `freestuff`, `free`, `garden`, `hobbies`, `homegoods`, `homeimprovement`, `homesales`, `musicalinstruments`, `officesupplies`, `petsupplies`, `sportinggoods`, `tickets`, `toys`, and `videogames`. If `catgory=freestuff` or `catgory=free` is set, `min_price` and `max_price` is ignored.
+8. `sort_by` controls the order of the search results. `suggested` (the default) uses Facebook's own ranking, `new` lists the newest items first (useful for catching newly listed items), `price_ascend` and `price_descend` sort by price, and `distance_ascend` sorts by distance from the search city.
 
 ### Regions
 

--- a/src/ai_marketplace_monitor/facebook.py
+++ b/src/ai_marketplace_monitor/facebook.py
@@ -354,7 +354,7 @@ class FacebookMarketplace(Marketplace):
             if self.config.username and self.config.password:
                 time.sleep(2)
                 # Facebook removed the <button name="login"> — press Enter to submit the form
-                self.page.keyboard.press('Enter')
+                self.page.keyboard.press("Enter")
         except KeyboardInterrupt:
             raise
         except Exception as e:
@@ -1030,9 +1030,11 @@ class FacebookRegularItemPage(FacebookItemPage):
 
 
 class FacebookFlexItemPage(FacebookRegularItemPage):
-    """Layout observed since mid-2026: the Details section renders Condition,
-    condition value, and description in nested span/div structures instead of
-    the previous ul/li lists. See #326."""
+    """Layout observed since mid-2026.
+
+    The Details section renders Condition, condition value, and description in
+    nested span/div structures instead of the previous ul/li lists. See #326.
+    """
 
     def verify_layout(self: "FacebookFlexItemPage") -> bool:
         return (
@@ -1041,8 +1043,11 @@ class FacebookFlexItemPage(FacebookRegularItemPage):
         )
 
     def _condition_and_description(self: "FacebookFlexItemPage") -> List[str]:
-        """Climb from the Condition label; the first non-empty next-sibling text
-        is the condition value, the second is the description."""
+        """Extract the condition value and description from the Details section.
+
+        Climb from the Condition label; the first non-empty next-sibling text
+        is the condition value, the second is the description.
+        """
         label = self.page.query_selector(f'span:text-is("{self.translator("Condition")}")')
         if label is None:
             return []

--- a/src/ai_marketplace_monitor/facebook.py
+++ b/src/ai_marketplace_monitor/facebook.py
@@ -79,6 +79,24 @@ class Category(Enum):
     VIDEO_GAMES = "videogames"
 
 
+class SortBy(Enum):
+    SUGGESTED = "suggested"
+    NEW = "new"
+    PRICE_ASCEND = "price_ascend"
+    PRICE_DESCEND = "price_descend"
+    DISTANCE_ASCEND = "distance_ascend"
+
+
+# facebook's `sortBy` query values, keyed by the accepted config value. `suggested`
+# is the marketplace default and is expressed by omitting the parameter altogether.
+SORT_BY_PARAM = {
+    SortBy.NEW.value: "creation_time_descend",
+    SortBy.PRICE_ASCEND.value: "price_ascend",
+    SortBy.PRICE_DESCEND.value: "price_descend",
+    SortBy.DISTANCE_ASCEND.value: "distance_ascend",
+}
+
+
 @dataclass
 class FacebookMarketItemCommonConfig(BaseConfig):
     """Item options that can be defined in marketplace
@@ -93,6 +111,7 @@ class FacebookMarketItemCommonConfig(BaseConfig):
     date_listed: List[int] | None = None
     delivery_method: List[str] | None = None
     category: str | None = None
+    sort_by: str | None = None
 
     def handle_seller_locations(self: "FacebookMarketItemCommonConfig") -> None:
         if self.seller_locations is None:
@@ -198,6 +217,15 @@ class FacebookMarketItemCommonConfig(BaseConfig):
         if not isinstance(self.category, str) or self.category not in [x.value for x in Category]:
             raise ValueError(
                 f"Item {hilight(self.name)} category must be one of {', '.join(x.value for x in Category)}."
+            )
+
+    def handle_sort_by(self: "FacebookMarketItemCommonConfig") -> None:
+        if self.sort_by is None:
+            return
+
+        if not isinstance(self.sort_by, str) or self.sort_by not in [x.value for x in SortBy]:
+            raise ValueError(
+                f"Item {hilight(self.name)} sort_by must be one of {', '.join(x.value for x in SortBy)}."
             )
 
 
@@ -398,6 +426,12 @@ class FacebookMarketplace(Marketplace):
             availability = Availability.ALL.value
         if availability is not None and availability != Availability.ALL.value:
             options.append(f"availability={availability}")
+
+        # sort order does not depend on the search city, so it is appended once here.
+        # `suggested` is facebook's default and needs no parameter.
+        sort_by = item_config.sort_by or self.config.sort_by
+        if sort_by and sort_by != SortBy.SUGGESTED.value:
+            options.append(f"sortBy={SORT_BY_PARAM[sort_by]}")
 
         # search multiple keywords and cities
         # there is a small chance that search by different keywords and city will return the same items.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,7 @@ def test_config(config_file: Callable, config_content: str, acceptable: bool) ->
         "search_phrases": list,
         "search_region": (list, type(None)),
         "searched_count": int,
+        "sort_by": (str, type(None)),
         "start_at": (list, type(None)),
         "username": (str, type(None)),
     }

--- a/tests/test_facebook_sort_by.py
+++ b/tests/test_facebook_sort_by.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ai_marketplace_monitor.facebook import SORT_BY_PARAM, FacebookItemConfig, SortBy
+
+
+def _item_config(**kwargs: object) -> FacebookItemConfig:
+    return FacebookItemConfig(
+        name="test_item",
+        search_phrases=["EMTB"],
+        **kwargs,
+    )
+
+
+def test_sort_by_defaults_to_none() -> None:
+    """When unspecified, sort_by stays None so no sortBy parameter is added."""
+    assert _item_config().sort_by is None
+
+
+@pytest.mark.parametrize("value", [s.value for s in SortBy])
+def test_sort_by_accepts_valid_values(value: str) -> None:
+    assert _item_config(sort_by=value).sort_by == value
+
+
+def test_sort_by_rejects_invalid_value() -> None:
+    with pytest.raises(ValueError, match="sort_by must be one of"):
+        _item_config(sort_by="oldest")
+
+
+def test_sort_by_param_mapping_covers_non_default_values() -> None:
+    """Every SortBy except the default `suggested` maps to a facebook query value."""
+    expected = {s.value for s in SortBy} - {SortBy.SUGGESTED.value}
+    assert set(SORT_BY_PARAM) == expected
+    assert SORT_BY_PARAM[SortBy.NEW.value] == "creation_time_descend"

--- a/tests/test_facebook_sort_by.py
+++ b/tests/test_facebook_sort_by.py
@@ -3,11 +3,11 @@ import pytest
 from ai_marketplace_monitor.facebook import SORT_BY_PARAM, FacebookItemConfig, SortBy
 
 
-def _item_config(**kwargs: object) -> FacebookItemConfig:
+def _item_config(sort_by: str | None = None) -> FacebookItemConfig:
     return FacebookItemConfig(
         name="test_item",
         search_phrases=["EMTB"],
-        **kwargs,
+        sort_by=sort_by,
     )
 
 


### PR DESCRIPTION
## Summary

Closes #323.

Adds a `sort_by` option that maps to Facebook Marketplace's own `sortBy` query parameter — the same mechanism all other filters are built on. This lets users order search results by **newest first** (the original request), price, or distance instead of Facebook's default `suggested` ranking, which is useful for catching newly listed items.

## Accepted values

| `sort_by` | Facebook `sortBy` param | Meaning |
|---|---|---|
| `suggested` *(default)* | *(omitted)* | Facebook's own ranking |
| `new` | `creation_time_descend` | newest first |
| `price_ascend` | `price_ascend` | cheapest first |
| `price_descend` | `price_descend` | priciest first |
| `distance_ascend` | `distance_ascend` | nearest first |

Friendly config values map to Facebook's internal strings (mirroring how `availability` uses `in`/`out`). Like `category`, `sort_by` is a single value and can be set in both `[marketplace.facebook]` and `[item.*]` sections, with the item value overriding the marketplace value.

## Changes

- `src/ai_marketplace_monitor/facebook.py` — `SortBy` enum + `SORT_BY_PARAM` map, `sort_by` config field, `handle_sort_by` validation, and the `sortBy=` append in `search()`
- `docs/README.md` — options table row + explanatory note
- `CHANGELOG.md` — `[Unreleased] › Added` entry
- `tests/test_facebook_sort_by.py` — validation + param-mapping tests

## Verification

- End-to-end URL construction exercised for every value: `sort_by="new"` produces `…/search?query=…&sortBy=creation_time_descend`; unset/`suggested` add no parameter (default behavior unchanged).
- New tests pass alongside existing facebook/ai tests; ruff/black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `sort_by` configuration option for Facebook Marketplace searches to control result ordering (suggested, newest, lowest price, highest price, or nearest listings). Suggested remains the default.
* **Documentation**
  * Updated the changelog and configuration docs to describe `sort_by` options and how they affect search ordering.
* **Tests**
  * Added automated coverage for `sort_by` defaults, accepted values, invalid input handling, and query parameter mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->