### PR TITLE
feat: Web UI Export CSV of found items (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Option `sort_by` to order Facebook search results by `suggested`, `new` (newest first), `price_ascend`, `price_descend`, or `distance_ascend` ([#323](https://github.com/BoPeng/ai-marketplace-monitor/issues/323))
+- Web UI "Export CSV" button that downloads all found (notified) listings with link, price, rating, and details ([#334](https://github.com/BoPeng/ai-marketplace-monitor/issues/334))
 
 ## [0.10.2]
 

--- a/docs/superpowers/plans/2026-07-16-export-found-csv.md
+++ b/docs/superpowers/plans/2026-07-16-export-found-csv.md
@@ -1,0 +1,676 @@
+# Export CSV of Found Items — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Web UI "Export CSV" button that downloads the matched/notified listings (link, price, rating, etc.) by reading and joining the existing on-disk cache.
+
+**Architecture:** A new pure-logic module `webui/found_export.py` enumerates and joins three `diskcache` namespaces (`USER_NOTIFIED`, `LISTING_DETAILS`, `AI_INQUIRY`) into CSV-ready rows. A thin authenticated `GET /api/found.csv` route in `webui/server.py` serializes those rows and returns them as a file download. The frontend adds one header button whose handler fetches the CSV with credentials and saves the blob. No scraping and no new persistent storage.
+
+**Tech Stack:** Python 3.10+, FastAPI, diskcache, stdlib `csv`; vanilla JS frontend (`app.js`); pytest + FastAPI `TestClient` for tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-07-16-export-found-csv-design.md`
+
+## Global Constraints
+
+- **Lint:** ruff + black + isort via pre-commit, `line-length = 99`. `BLE001` (blind `except`), `E501` (line length), `D100–D103/D107/D415` (missing docstrings) are ignored; but `D205` (blank line after a docstring summary) is enforced — any docstring you write must be well-formed. Docstring convention is **google**.
+- **Types:** ruff `ANN` is enforced (except `ANN002/003/202/401`) and `mypy` runs over `src`, `tests`, `noxfile.py`, `tasks.py`, `docs/conf.py`. **Every function — including test functions and helpers — needs parameter and return type annotations.**
+- **Broad excepts** must re-raise `KeyboardInterrupt` before catching `Exception`, matching the existing pattern in `listing.py`/`ai.py`.
+- **Auth:** reads use `Depends(require_session)` only (no `require_csrf`), matching `/api/status` and `/api/logs`.
+- **Pre-existing debt:** `main` currently carries lint debt from earlier merges (#336 `'Enter'` quoting, #326 `FacebookFlexItemPage` D205 docstrings) that makes `pre-commit run --all-files` fail on any branch off `main`. This is fixed on branch `feat/sort-by-323` (PR #340). Before opening this PR, rebase onto `main` once #340 has merged, or cherry-pick its lint-fix commit (`9a0dd09`). See Task 5.
+- **Branch:** work happens on `feat/export-found-csv-334` (already created off `main`).
+
+## File Structure
+
+- **Create** `src/ai_marketplace_monitor/webui/found_export.py` — pure join + CSV serialization. No FastAPI, no HTTP, no global-cache import. One responsibility: turn a `Cache` into CSV text.
+- **Modify** `src/ai_marketplace_monitor/webui/server.py` — add imports and one `GET /api/found.csv` route inside `create_app`.
+- **Modify** `src/ai_marketplace_monitor/webui/static/index.html` — add the export button to the header.
+- **Modify** `src/ai_marketplace_monitor/webui/static/app.js` — wire the button click to a download handler.
+- **Create** `tests/test_found_export.py` — unit tests for the module + one endpoint test via `TestClient`.
+- **Modify** `CHANGELOG.md` — `[Unreleased] › Added` entry.
+- **Modify** `docs/README.md` — one-line mention in the Web UI section (optional copy; see Task 4).
+
+---
+
+### Task 1: CSV serializer + column schema
+
+**Files:**
+- Create: `src/ai_marketplace_monitor/webui/found_export.py`
+- Test: `tests/test_found_export.py`
+
+**Interfaces:**
+- Produces: `CSV_COLUMNS: List[str]` (canonical ordered columns) and `rows_to_csv(rows: List[Dict[str, str]]) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_found_export.py`:
+
+```python
+"""Tests for the Web UI found-items CSV export."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Dict, List
+
+from ai_marketplace_monitor.webui.found_export import CSV_COLUMNS, rows_to_csv
+
+
+def _parse(text: str) -> List[Dict[str, str]]:
+    return list(csv.DictReader(io.StringIO(text)))
+
+
+def test_rows_to_csv_empty_has_header_only() -> None:
+    text = rows_to_csv([])
+    lines = text.splitlines()
+    assert lines[0].split(",") == CSV_COLUMNS
+    assert len(lines) == 1
+
+
+def test_rows_to_csv_writes_row_and_escapes() -> None:
+    row = {c: "" for c in CSV_COLUMNS}
+    row["title"] = 'Chair, "comfy"'
+    row["price"] = "$40"
+    text = rows_to_csv([row])
+    parsed = _parse(text)
+    assert len(parsed) == 1
+    assert parsed[0]["title"] == 'Chair, "comfy"'
+    assert parsed[0]["price"] == "$40"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'ai_marketplace_monitor.webui.found_export'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/ai_marketplace_monitor/webui/found_export.py`:
+
+```python
+"""Build and serialize the "found items" export from the on-disk cache.
+
+Reads the notified/matched listings out of the diskcache and joins them with
+cached listing details and AI ratings to produce CSV-ready rows.  Read-only:
+no scraping and no new persistence.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Dict, List
+
+CSV_COLUMNS: List[str] = [
+    "found_at",
+    "item",
+    "marketplace",
+    "title",
+    "price",
+    "rating",
+    "ai_comment",
+    "location",
+    "seller",
+    "condition",
+    "notified_user",
+    "url",
+]
+
+
+def rows_to_csv(rows: List[Dict[str, str]]) -> str:
+    """Serialize rows to CSV text with a fixed header and column order."""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_marketplace_monitor/webui/found_export.py tests/test_found_export.py
+git commit -m "feat: CSV serializer + column schema for found-items export (#334)"
+```
+
+---
+
+### Task 2: Join builder (`build_found_rows`)
+
+**Files:**
+- Modify: `src/ai_marketplace_monitor/webui/found_export.py`
+- Test: `tests/test_found_export.py`
+
+**Interfaces:**
+- Consumes: `CacheType` from `ai_marketplace_monitor.utils`; `diskcache.Cache`.
+- Produces: `build_found_rows(local_cache: Cache) -> List[Dict[str, str]]` — one row dict (keyed by `CSV_COLUMNS`) per `USER_NOTIFIED` entry, sorted by `found_at` descending.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_found_export.py`:
+
+```python
+from pathlib import Path  # noqa: E402
+from typing import Iterator  # noqa: E402
+
+import pytest  # noqa: E402
+from diskcache import Cache  # type: ignore  # noqa: E402
+
+from ai_marketplace_monitor.listing import Listing  # noqa: E402
+from ai_marketplace_monitor.utils import CacheType  # noqa: E402
+from ai_marketplace_monitor.webui.found_export import build_found_rows  # noqa: E402
+
+
+def _listing(listing_id: str = "123", price: str = "$100") -> Listing:
+    return Listing(
+        marketplace="facebook",
+        name="iphone",
+        id=listing_id,
+        title="iPhone 13",
+        image="http://img/x.jpg",
+        price=price,
+        post_url=f"https://www.facebook.com/marketplace/item/{listing_id}/?ref=search",
+        location="Houston, TX",
+        seller="Jane Doe",
+        condition="used_good",
+        description="great phone",
+    )
+
+
+@pytest.fixture
+def temp_cache(tmp_path: Path) -> Iterator[Cache]:
+    cache = Cache(str(tmp_path / "cache"))
+    yield cache
+    cache.close()
+
+
+def _seed_notified(cache: Cache, listing: Listing, user: str = "me",
+                   date: str = "2026-07-16 10:00:00") -> None:
+    cache.set(
+        (CacheType.USER_NOTIFIED.value, listing.marketplace, listing.id, user),
+        (date, listing.hash, listing.price),
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+
+
+def _seed_rating(cache: Cache, listing: Listing, score: int = 5,
+                 comment: str = "Great deal") -> None:
+    cache.set(
+        (CacheType.AI_INQUIRY.value, "itemhash", "mkthash", listing.hash),
+        {"score": score, "comment": comment, "name": ""},
+        tag=CacheType.AI_INQUIRY.value,
+    )
+
+
+def test_build_rows_full_join(temp_cache: Cache) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, listing)
+    _seed_notified(temp_cache, listing)
+
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["found_at"] == "2026-07-16 10:00:00"
+    assert row["item"] == "iphone"
+    assert row["marketplace"] == "facebook"
+    assert row["title"] == "iPhone 13"
+    assert row["price"] == "$100"
+    assert row["rating"] == "5"
+    assert row["ai_comment"] == "Great deal"
+    assert row["location"] == "Houston, TX"
+    assert row["seller"] == "Jane Doe"
+    assert row["condition"] == "used_good"
+    assert row["notified_user"] == "me"
+    assert row["url"] == "https://www.facebook.com/marketplace/item/123/?ref=search"
+
+
+def test_build_rows_missing_details_uses_fallback_url(temp_cache: Cache) -> None:
+    listing = _listing()
+    _seed_notified(temp_cache, listing)  # no LISTING_DETAILS, no rating
+
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 1
+    assert rows[0]["title"] == ""
+    assert rows[0]["rating"] == ""
+    assert rows[0]["url"] == "https://www.facebook.com/marketplace/item/123/"
+
+
+def test_build_rows_legacy_notified_value_shapes(temp_cache: Cache) -> None:
+    listing = _listing()
+    # legacy: bare date string
+    temp_cache.set(
+        (CacheType.USER_NOTIFIED.value, "facebook", "aaa", "me"),
+        "2026-07-15 09:00:00",
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+    # legacy: 2-tuple (date, hash)
+    temp_cache.set(
+        (CacheType.USER_NOTIFIED.value, "facebook", "bbb", "me"),
+        ("2026-07-15 09:30:00", listing.hash),
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 2
+    assert {r["found_at"] for r in rows} == {"2026-07-15 09:00:00", "2026-07-15 09:30:00"}
+
+
+def test_build_rows_multi_user_two_rows(temp_cache: Cache) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_notified(temp_cache, listing, user="alice")
+    _seed_notified(temp_cache, listing, user="bob")
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 2
+    assert {r["notified_user"] for r in rows} == {"alice", "bob"}
+
+
+def test_build_rows_sorted_by_found_at_desc(temp_cache: Cache) -> None:
+    old, new = _listing("111"), _listing("222")
+    _seed_notified(temp_cache, old, date="2026-07-10 08:00:00")
+    _seed_notified(temp_cache, new, date="2026-07-16 08:00:00")
+    rows = build_found_rows(temp_cache)
+    assert [r["found_at"] for r in rows] == ["2026-07-16 08:00:00", "2026-07-10 08:00:00"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -q`
+Expected: FAIL — `ImportError: cannot import name 'build_found_rows'`
+
+- [ ] **Step 3: Write the implementation**
+
+Edit `src/ai_marketplace_monitor/webui/found_export.py`. Change the imports block and append the join logic:
+
+Replace the import block:
+
+```python
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any, Dict, List, Optional, Tuple
+
+from diskcache import Cache  # type: ignore
+
+from ..utils import CacheType
+```
+
+Append after `CSV_COLUMNS`:
+
+```python
+def _normalize_notified(value: Any) -> Tuple[str, Optional[str], Optional[str]]:
+    """Return (date, listing_hash, price) from a USER_NOTIFIED cache value.
+
+    Handles legacy shapes: a bare date string, a 2-tuple (date, hash), or the
+    current 3-tuple (date, hash, price).
+    """
+    if isinstance(value, str):
+        return value, None, None
+    if isinstance(value, (tuple, list)):
+        if len(value) == 2:
+            return value[0], value[1], None
+        if len(value) >= 3:
+            return value[0], value[1], value[2]
+    return "", None, None
+
+
+def _fallback_url(marketplace: str, listing_id: str) -> str:
+    """Reconstruct a listing URL when its details are no longer cached."""
+    if marketplace == "facebook":
+        return f"https://www.facebook.com/marketplace/item/{listing_id}/"
+    return ""
+
+
+def build_found_rows(local_cache: Cache) -> List[Dict[str, str]]:
+    """Join notified items with details and ratings into CSV-ready rows.
+
+    Emits one row per USER_NOTIFIED entry (i.e. per listing per user), sorted
+    by found_at descending.  Malformed or legacy cache entries are skipped.
+    """
+    details_by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    rating_by_hash: Dict[str, Dict[str, Any]] = {}
+    notified: List[Tuple[str, str, str, str, Optional[str], Optional[str]]] = []
+
+    for key in local_cache.iterkeys():
+        if not isinstance(key, tuple) or not key:
+            continue
+        tag = key[0]
+        try:
+            if tag == CacheType.LISTING_DETAILS.value:
+                value = local_cache.get(key)
+                if isinstance(value, dict) and "id" in value and "marketplace" in value:
+                    details_by_key[(value["marketplace"], value["id"])] = value
+            elif tag == CacheType.AI_INQUIRY.value and len(key) >= 4:
+                value = local_cache.get(key)
+                if isinstance(value, dict):
+                    rating_by_hash[key[3]] = value
+            elif tag == CacheType.USER_NOTIFIED.value and len(key) >= 4:
+                date, listing_hash, price = _normalize_notified(local_cache.get(key))
+                notified.append((key[1], key[2], key[3], date, listing_hash, price))
+        except KeyboardInterrupt:
+            raise
+        except Exception:
+            continue
+
+    rows: List[Dict[str, str]] = []
+    for marketplace, listing_id, user, date, listing_hash, price in notified:
+        details = details_by_key.get((marketplace, listing_id)) or {}
+        rating = (rating_by_hash.get(listing_hash) if listing_hash else None) or {}
+        rows.append(
+            {
+                "found_at": date or "",
+                "item": details.get("name", "") or "",
+                "marketplace": marketplace,
+                "title": details.get("title", "") or "",
+                "price": (price if price is not None else details.get("price", "")) or "",
+                "rating": str(rating["score"]) if "score" in rating else "",
+                "ai_comment": rating.get("comment", "") or "",
+                "location": details.get("location", "") or "",
+                "seller": details.get("seller", "") or "",
+                "condition": details.get("condition", "") or "",
+                "notified_user": user,
+                "url": details.get("post_url") or _fallback_url(marketplace, listing_id),
+            }
+        )
+
+    rows.sort(key=lambda r: r["found_at"], reverse=True)
+    return rows
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Run mypy on the new module + tests**
+
+Run: `uv run --with mypy --extra test mypy src/ai_marketplace_monitor/webui/found_export.py tests/test_found_export.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai_marketplace_monitor/webui/found_export.py tests/test_found_export.py
+git commit -m "feat: join notified items into found-items rows (#334)"
+```
+
+---
+
+### Task 3: `GET /api/found.csv` endpoint
+
+**Files:**
+- Modify: `src/ai_marketplace_monitor/webui/server.py` (add imports near the other `.`/`..` imports around lines 37–50; add the route inside `create_app`, just before `return app` at line 468)
+- Modify: `CHANGELOG.md`
+- Test: `tests/test_found_export.py`
+
+**Interfaces:**
+- Consumes: `build_found_rows`, `rows_to_csv` from `.found_export`; module-global `cache` from `..utils`; the `create_app`-local `require_session` dependency; `Response` (already imported at server.py line 30); `time` (already imported line 17).
+- Produces: HTTP `GET /api/found.csv` → `200 text/csv` attachment, or `401` when exposed without a session.
+
+- [ ] **Step 1: Write the failing endpoint tests**
+
+Append to `tests/test_found_export.py`:
+
+```python
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ai_marketplace_monitor.webui import server as webui_server  # noqa: E402
+from ai_marketplace_monitor.webui.config_api import ConfigFileService  # noqa: E402
+from ai_marketplace_monitor.webui.log_handler import LogBroadcastHandler  # noqa: E402
+from ai_marketplace_monitor.webui.server import AuthState, WebUIConfig, create_app  # noqa: E402
+
+
+def _make_client(tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch,
+                 exposed: bool = False) -> TestClient:
+    monkeypatch.setattr(webui_server, "cache", temp_cache)
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("[marketplace.facebook]\nsearch_city = 'dallas'\n", encoding="utf-8")
+    handler = LogBroadcastHandler()
+    config = WebUIConfig(config_files=[cfg_file], log_handler=handler)
+    state = AuthState()
+    state.exposed = exposed
+    service = ConfigFileService([cfg_file])
+    app = create_app(config, state, service, handler)
+    return TestClient(app)
+
+
+def test_endpoint_returns_csv(
+    tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, listing)
+    _seed_notified(temp_cache, listing)
+
+    client = _make_client(tmp_path, temp_cache, monkeypatch)
+    resp = client.get("/api/found.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "attachment" in resp.headers["content-disposition"]
+    parsed = list(csv.DictReader(io.StringIO(resp.text)))
+    assert len(parsed) == 1
+    assert parsed[0]["rating"] == "5"
+    assert parsed[0]["url"].startswith("https://www.facebook.com/marketplace/item/123/")
+
+
+def test_endpoint_requires_session_when_exposed(
+    tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _make_client(tmp_path, temp_cache, monkeypatch, exposed=True)
+    resp = client.get("/api/found.csv")
+    assert resp.status_code == 401
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -k endpoint -q`
+Expected: FAIL — the CSV test gets `404` (route not registered); import of `webui_server.cache` may also fail until the import is added in Step 3.
+
+- [ ] **Step 3: Add imports to `server.py`**
+
+After the existing `from .log_handler import LogBroadcastHandler` line (around line 50), add:
+
+```python
+from ..utils import cache
+from .found_export import build_found_rows, rows_to_csv
+```
+
+- [ ] **Step 4: Register the route in `create_app`**
+
+Immediately before `return app` (server.py line 468), add:
+
+```python
+    @app.get("/api/found.csv")
+    async def export_found_csv(_: str = Depends(require_session)) -> Response:
+        csv_text = rows_to_csv(build_found_rows(cache))
+        filename = f"found-items-{time.strftime('%Y%m%d-%H%M%S')}.csv"
+        return Response(
+            content=csv_text,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run --extra test pytest tests/test_found_export.py -q`
+Expected: PASS (9 passed)
+
+- [ ] **Step 6: Add CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]`, add an `### Added` block (create it if absent):
+
+```markdown
+### Added
+- Web UI "Export CSV" button that downloads all found (notified) listings with link, price, rating, and details ([#334](https://github.com/BoPeng/ai-marketplace-monitor/issues/334))
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai_marketplace_monitor/webui/server.py tests/test_found_export.py CHANGELOG.md
+git commit -m "feat: add GET /api/found.csv export endpoint (#334)"
+```
+
+---
+
+### Task 4: Frontend button + download handler
+
+**Files:**
+- Modify: `src/ai_marketplace_monitor/webui/static/index.html` (header-right block, around line 34–38)
+- Modify: `src/ai_marketplace_monitor/webui/static/app.js` (add a `wireClick` handler near the `#restart-btn` handler at line 538)
+- Modify: `docs/README.md` (Web UI section — one line)
+
+**Interfaces:**
+- Consumes: existing `wireClick(sel, fn)`, `$(sel)`, `api(path, opts)` (returns `Response`, redirects to login on 401), `setEditorStatus(msg, kind)` from `app.js`; the `GET /api/found.csv` route from Task 3.
+
+- [ ] **Step 1: Add the button to `index.html`**
+
+In the `<div class="header-right">` block, insert before the `#logout-btn` button:
+
+```html
+        <button id="export-csv-btn" class="ghost small" title="Download all found items as CSV" aria-label="Download all found items as CSV">⬇ Export CSV</button>
+```
+
+- [ ] **Step 2: Add the click handler to `app.js`**
+
+After the `wireClick("#restart-btn", …)` block (which ends around line 552), add:
+
+```javascript
+  wireClick("#export-csv-btn", async () => {
+    const btn = $("#export-csv-btn");
+    if (btn) btn.disabled = true;
+    try {
+      const res = await api("/api/found.csv");
+      if (!res.ok) {
+        setEditorStatus("⬇ Export failed: " + res.status, "err");
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const stamp = new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace(/[-:T]/g, "")
+        .replace(/(\d{8})(\d{6})/, "$1-$2");
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `found-items-${stamp}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setEditorStatus("⬇ Export failed: " + err.message, "err");
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  });
+```
+
+- [ ] **Step 3: Add a docs mention**
+
+In `docs/README.md`, in the Web UI section, add one sentence (adapt wording to the surrounding prose): "An **Export CSV** button in the header downloads all found (notified) listings — link, price, rating, and details — as a CSV file."
+
+- [ ] **Step 4: Manual verification (no JS test harness in this repo)**
+
+Run the Web UI against a config that has produced notifications (or seed the cache), then:
+
+```bash
+uv run ai-marketplace-monitor --webui --config <your-config.toml>
+```
+
+- Open the UI, confirm the **⬇ Export CSV** button appears in the header.
+- Click it; confirm a `found-items-YYYYMMDD-HHMMSS.csv` downloads.
+- Open the CSV; confirm the header row matches `found_at,item,marketplace,title,price,rating,ai_comment,location,seller,condition,notified_user,url` and that rows contain your notified items.
+- Confirm the button briefly disables during the request and re-enables after.
+
+If you have no real notifications yet, verify at least that the button downloads a header-only CSV without error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_marketplace_monitor/webui/static/index.html src/ai_marketplace_monitor/webui/static/app.js docs/README.md
+git commit -m "feat: Export CSV button in Web UI header (#334)"
+```
+
+---
+
+### Task 5: Full verification + PR
+
+**Files:** none (verification + git/gh only)
+
+- [ ] **Step 1: Resolve pre-existing lint debt if present**
+
+`pre-commit run --all-files` lints the whole repo, including the #336/#326 debt still on `main`. If PR #340 (`feat/sort-by-323`) has merged, rebase:
+
+```bash
+git fetch origin && git rebase origin/main
+```
+
+If #340 has **not** merged, cherry-pick its lint-fix commit so this branch is green on its own:
+
+```bash
+git cherry-pick 9a0dd09   # style: fix pre-existing black/ruff lint errors in facebook.py
+```
+
+- [ ] **Step 2: Run the full pre-commit suite**
+
+Run: `uv run --with pre-commit pre-commit run --all-files`
+Expected: all hooks pass (black, ruff, isort, etc.).
+
+- [ ] **Step 3: Run mypy over all targets (matches CI)**
+
+Run: `uv run --with mypy --extra test mypy src tests`
+Expected: `Success: no issues found`
+
+- [ ] **Step 4: Run the full test suite (matches CI)**
+
+Run: `uv run --extra test pytest -q`
+Expected: all pass (previous baseline 157 passed, 1 skipped; +9 new = 166 passed, 1 skipped).
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+gh auth switch --user BoPeng
+GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=credential.helper GIT_CONFIG_VALUE_0="!gh auth git-credential" \
+  git push -u origin feat/export-found-csv-334
+gh pr create --repo BoPeng/ai-marketplace-monitor --base main \
+  --title "feat: Web UI Export CSV of found items (#334)" \
+  --body "Closes #334. Adds an authenticated GET /api/found.csv endpoint and a header button that downloads all found (notified) listings — link, price, rating, and details — by reading and joining the existing diskcache. No scraping, no new storage."
+```
+
+- [ ] **Step 6: Confirm CI is green**
+
+Run: `gh pr checks <PR#> --repo BoPeng/ai-marketplace-monitor`
+Expected: Linting, all test-matrix jobs, CodeQL, Analyze all pass. Do not report done until green.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Scope = notified items → Task 2 spine is `USER_NOTIFIED`. ✅
+- Three-cache join, enumerate by tag → Task 2 `build_found_rows`. ✅
+- Columns (12, fixed order) → Task 1 `CSV_COLUMNS`, asserted in tests. ✅
+- Legacy `USER_NOTIFIED` normalization → Task 2 `_normalize_notified` + test. ✅
+- Missing details / missing rating fallbacks → Task 2 tests. ✅
+- Facebook fallback URL → Task 2 `_fallback_url` + test. ✅
+- One row per (listing, user) → Task 2 multi-user test. ✅
+- Sorted by found_at desc → Task 2 test. ✅
+- Endpoint, `require_session` only, CSV headers → Task 3 + tests (200 + 401). ✅
+- Frontend button + fetch/blob download, disable-in-flight → Task 4. ✅
+- Empty cache → header-only CSV → covered by Task 1 empty test + Task 4 manual note. ✅
+- Docs/CHANGELOG → Tasks 3 & 4. ✅
+- Testing (unit + endpoint) → Tasks 1–3. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✅
+
+**Type consistency:** `CSV_COLUMNS`, `rows_to_csv(rows)`, `build_found_rows(local_cache)`, `_normalize_notified(value)`, `_fallback_url(marketplace, listing_id)` are used with identical names/signatures across tasks. Endpoint reads module-global `cache` (monkeypatched in tests via `webui_server.cache`). ✅

--- a/docs/superpowers/specs/2026-07-16-export-found-csv-design.md
+++ b/docs/superpowers/specs/2026-07-16-export-found-csv-design.md
@@ -1,0 +1,180 @@
+# Design: Export CSV of found items (Web UI)
+
+**Issue:** [#334](https://github.com/BoPeng/ai-marketplace-monitor/issues/334) — "List of all found items"
+**Date:** 2026-07-16
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Summary
+
+Add an **"Export CSV"** button to the Web UI that downloads the list of items the
+monitor has **found and notified users about**, with link, price, rating, and the
+core listing fields. The data already exists on disk in the `diskcache`; this feature
+only reads and joins it — it performs no scraping and adds no new persistent storage.
+
+## Scope decision: which items?
+
+"Found items" means the **matched/notified** listings — the ones the monitor decided
+were worth surfacing to a user — **not** every listing the crawler scraped. Rationale:
+
+- The issue explicitly requests a `rating` column. Ratings only exist for
+  AI‑evaluated listings, which are exactly the ones that get notified. Exporting all
+  scraped listings would leave most `rating` cells blank and include filtered‑out noise.
+- The notified set joins cleanly: `USER_NOTIFIED` stores `listing.hash`, which keys
+  `AI_INQUIRY` directly, so the rating join needs no fragile hash recomputation.
+
+**Out of scope (YAGNI):** in‑UI table/browse view, filtering / date‑range params,
+per‑user files, configurable columns, exporting all scraped listings.
+
+## Data sources (existing cache)
+
+Single on‑disk cache: `cache = Cache(amm_home)` in `utils.py`. Entries are tagged by
+`CacheType` and enumerable via `cache.iterkeys()` (the counters code in `utils.py`
+already uses this pattern, filtering on `key[0]`).
+
+| `CacheType`       | Key                                              | Value                                  | Provides                                              |
+| ----------------- | ------------------------------------------------ | -------------------------------------- | ---------------------------------------------------- |
+| `USER_NOTIFIED`   | `(tag, marketplace, id, user)`                   | `(date, listing_hash, price)`¹         | row spine: found‑timestamp, user, price, listing hash |
+| `LISTING_DETAILS` | `(tag, post_url_without_query)`                  | full `Listing` dict                    | title, url, location, seller, condition, item name    |
+| `AI_INQUIRY`      | `(tag, item_hash, mkt_hash, listing_hash)`       | `{score, comment, name}` (asdict)      | rating (`score` 1–5) and AI `comment`                 |
+
+¹ Legacy `USER_NOTIFIED` values may be a bare `str` (date only) or a 2‑tuple
+`(date, hash)`. Normalized the same way `User.notification_status` in `user.py`
+already does.
+
+`Listing` fields (from `listing.py`): `marketplace, name, id, title, image, price,
+post_url, location, seller, condition, description`. `Listing.name` is the **item
+config name** (set at `facebook.py`: `listing.name = item_config.name`).
+
+## Architecture
+
+Two small, independently testable units plus one wiring change:
+
+1. **`webui/found_export.py`** — pure logic, no HTTP, no FastAPI.
+   - `build_found_rows(cache) -> list[dict]`: enumerate + join the three cache
+     namespaces, return sorted row dicts (one per notified record).
+   - `rows_to_csv(rows) -> str`: serialize rows to CSV text with a fixed column order,
+     using the stdlib `csv` module.
+   - `CSV_COLUMNS`: the canonical ordered column list (single source of truth, shared
+     by `rows_to_csv` and tests).
+2. **`GET /api/found.csv`** endpoint in `webui/server.py` — thin wrapper: build rows →
+   CSV → return `Response` with download headers. Auth only (no CSRF; it's a read).
+3. **Frontend** — one button in the header + a click handler in `app.js` that fetches
+   with credentials and saves the resulting blob.
+
+## Backend detail
+
+### Join algorithm (`build_found_rows`)
+
+```
+details_by_key = {}          # (marketplace, id) -> Listing dict
+rating_by_hash = {}          # listing_hash -> {score, comment}
+notified = []                # (marketplace, id, user, date, listing_hash, price)
+
+for key in cache.iterkeys():
+    tag = key[0]
+    if tag == LISTING_DETAILS:  index cache[key] by (value["marketplace"], value["id"])
+    elif tag == AI_INQUIRY:     rating_by_hash[key[3]] = cache[key]   # last wins
+    elif tag == USER_NOTIFIED:  normalize value -> (date, hash, price); collect with key[1:]
+
+for each notified record:
+    d = details_by_key.get((marketplace, id))          # may be None
+    r = rating_by_hash.get(listing_hash)               # may be None
+    row = {
+        found_at:      date,
+        item:          d["name"] if d else "",
+        marketplace:   marketplace,
+        title:         d["title"] if d else "",
+        price:         price (from notified record; fall back to d["price"]),
+        rating:        r["score"] if r else "",
+        ai_comment:    r["comment"] if r else "",
+        location:      d["location"] if d else "",
+        seller:        d["seller"] if d else "",
+        condition:     d["condition"] if d else "",
+        notified_user: user,
+        url:           d["post_url"] if d else fallback_url(marketplace, id),
+    }
+
+sort rows by found_at descending
+```
+
+`fallback_url(marketplace, id)`: for `facebook`, `https://www.facebook.com/marketplace/item/<id>/`;
+otherwise empty string. (Lets a row survive detail eviction without losing the link.)
+
+**Columns (fixed order):**
+`found_at, item, marketplace, title, price, rating, ai_comment, location, seller, condition, notified_user, url`
+
+**Row cardinality:** one row per `USER_NOTIFIED` entry, i.e. per (listing, user). A
+listing notified to two users yields two rows; `notified_user` disambiguates. This is
+lossless and matches the stored data.
+
+**Robustness:** each cache entry is processed defensively — a single malformed/legacy
+entry is skipped (and logged at debug), never aborting the whole export.
+
+### Endpoint
+
+```python
+@app.get("/api/found.csv")
+async def export_found(_: str = Depends(require_session)) -> Response:
+    csv_text = rows_to_csv(build_found_rows(cache))
+    filename = f"found-items-{now:%Y%m%d-%H%M%S}.csv"
+    return Response(
+        content=csv_text,
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+```
+
+- `Depends(require_session)` only — mirrors `/api/status` and `/api/logs` (both reads).
+  No `require_csrf` (that guards state changes).
+- Empty cache / no users → 200 with a header‑only CSV.
+- `cache` and `CacheType` imported from `..utils`.
+
+## Frontend detail
+
+- **Button:** a small ghost button in the header toolbar (next to the `Browser` /
+  `Logout` buttons in `index.html`), e.g. `<button id="export-csv-btn" class="ghost">⬇ Export CSV</button>`.
+- **Handler (`app.js`):** on click, `fetch("/api/found.csv", {credentials:"same-origin"})`;
+  on success read `blob()`, create an object URL, click a temporary
+  `<a download="found-items-YYYYMMDD-HHMMSS.csv">`, then revoke the URL. Disable the
+  button while the request is in flight.
+- Using fetch+blob (not a bare `<a href>`) so a `401` surfaces as a handled error
+  instead of navigating the browser to a JSON error body.
+
+## Error handling
+
+| Condition                        | Behavior                                                        |
+| -------------------------------- | -------------------------------------------------------------- |
+| No session                       | `401` (via `require_session`); frontend shows an error, no file |
+| Empty / no notified items        | `200`, CSV with only the header row                            |
+| Malformed/legacy cache entry     | Entry skipped, logged at debug; export continues               |
+| Missing `LISTING_DETAILS`        | Row emitted with blanks + fallback URL                         |
+| Missing `AI_INQUIRY`             | Row emitted with blank `rating`/`ai_comment`                   |
+
+## Testing
+
+**Unit — `build_found_rows` / `rows_to_csv`** (against a temporary `diskcache.Cache`,
+matching the temp‑cache style already used in the suite):
+- Happy path: all three caches populated → one fully‑joined row, correct field mapping.
+- Missing details → row present with blanks and Facebook fallback URL.
+- Missing rating → blank `rating`/`ai_comment`.
+- Legacy `USER_NOTIFIED` value shapes (bare str, 2‑tuple) normalized without error.
+- Same listing notified to two users → two rows, distinct `notified_user`.
+- Sorting: rows ordered by `found_at` descending.
+- `rows_to_csv`: header row equals `CSV_COLUMNS`; values comma/quote‑escaped correctly.
+
+**Endpoint — FastAPI `TestClient`** (mirrors existing webui tests):
+- Seeded cache → `GET /api/found.csv` returns `200`, `text/csv` content type,
+  `attachment` disposition, body parses to the expected rows.
+- Without a session cookie → `401`.
+
+## Documentation
+
+- `CHANGELOG.md`: `[Unreleased] › Added` entry referencing #334.
+- Brief mention in the Web UI section of the docs that an "Export CSV" of found items
+  is available.
+
+## Non‑goals / future
+
+- In‑UI sortable table of found items (a possible follow‑up; the export button is the
+  concrete ask).
+- Exporting all scraped listings, filtering, or date ranges.

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -11,6 +11,7 @@ The web UI provides:
 - **TOML Config Editor** with syntax highlighting, powered by CodeMirror
 - **Add / Edit / Delete** config sections (items, AI backends, users, marketplaces) through guided forms
 - **Live Log Streaming** with filtering by level, item, AI score, and text search
+- **Export CSV** button in the header downloads all found (notified) listings — link, price, rating, and details — as a CSV file
 - **Auto-validation** of your config as you type
 
 ## Getting Started

--- a/src/ai_marketplace_monitor/webui/found_export.py
+++ b/src/ai_marketplace_monitor/webui/found_export.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import csv
 import io
-from typing import Dict, List
+from typing import Any, Dict, List, Optional, Tuple
+
+from diskcache import Cache  # type: ignore
+
+from ..utils import CacheType
 
 CSV_COLUMNS: List[str] = [
     "found_at",
@@ -25,6 +29,85 @@ CSV_COLUMNS: List[str] = [
     "notified_user",
     "url",
 ]
+
+
+def _normalize_notified(value: Any) -> Tuple[str, Optional[str], Optional[str]]:
+    """Return (date, listing_hash, price) from a USER_NOTIFIED cache value.
+
+    Handles legacy shapes: a bare date string, a 2-tuple (date, hash), or the
+    current 3-tuple (date, hash, price).
+    """
+    if isinstance(value, str):
+        return value, None, None
+    if isinstance(value, (tuple, list)):
+        if len(value) == 2:
+            return value[0], value[1], None
+        if len(value) >= 3:
+            return value[0], value[1], value[2]
+    return "", None, None
+
+
+def _fallback_url(marketplace: str, listing_id: str) -> str:
+    """Reconstruct a listing URL when its details are no longer cached."""
+    if marketplace == "facebook":
+        return f"https://www.facebook.com/marketplace/item/{listing_id}/"
+    return ""
+
+
+def build_found_rows(local_cache: Cache) -> List[Dict[str, str]]:
+    """Join notified items with details and ratings into CSV-ready rows.
+
+    Emits one row per USER_NOTIFIED entry (i.e. per listing per user), sorted
+    by found_at descending.  Malformed or legacy cache entries are skipped.
+    """
+    details_by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    rating_by_hash: Dict[str, Dict[str, Any]] = {}
+    notified: List[Tuple[str, str, str, str, Optional[str], Optional[str]]] = []
+
+    for key in local_cache.iterkeys():
+        if not isinstance(key, tuple) or not key:
+            continue
+        tag = key[0]
+        try:
+            if tag == CacheType.LISTING_DETAILS.value:
+                value = local_cache.get(key)
+                if isinstance(value, dict) and "id" in value and "marketplace" in value:
+                    details_by_key[(value["marketplace"], value["id"])] = value
+            elif tag == CacheType.AI_INQUIRY.value and len(key) >= 4:
+                value = local_cache.get(key)
+                if isinstance(value, dict):
+                    rating_by_hash[key[3]] = value
+            elif tag == CacheType.USER_NOTIFIED.value and len(key) >= 4:
+                date, listing_hash, price = _normalize_notified(local_cache.get(key))
+                notified.append((key[1], key[2], key[3], date, listing_hash, price))
+        except KeyboardInterrupt:
+            raise
+        except Exception:
+            continue
+
+    rows: List[Dict[str, str]] = []
+    for marketplace, listing_id, user, date, listing_hash, price in notified:
+        details = details_by_key.get((marketplace, listing_id)) or {}
+        rating = (rating_by_hash.get(listing_hash) if listing_hash else None) or {}
+        rows.append(
+            {
+                "found_at": date or "",
+                "item": details.get("name", "") or "",
+                "marketplace": marketplace,
+                "title": details.get("title", "") or "",
+                "price": (price if price is not None else details.get("price", "")) or "",
+                "rating": str(rating["score"]) if "score" in rating else "",
+                "ai_comment": rating.get("comment", "") or "",
+                "location": details.get("location", "") or "",
+                "seller": details.get("seller", "") or "",
+                "condition": details.get("condition", "") or "",
+                "notified_user": user,
+                "url": details.get("post_url") or _fallback_url(marketplace, listing_id),
+            }
+        )
+
+    rows.sort(key=lambda r: r["found_at"], reverse=True)
+    return rows
 
 
 def rows_to_csv(rows: List[Dict[str, str]]) -> str:

--- a/src/ai_marketplace_monitor/webui/found_export.py
+++ b/src/ai_marketplace_monitor/webui/found_export.py
@@ -1,0 +1,37 @@
+"""Build and serialize the "found items" export from the on-disk cache.
+
+Reads the notified/matched listings out of the diskcache and joins them with
+cached listing details and AI ratings to produce CSV-ready rows.  Read-only:
+no scraping and no new persistence.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Dict, List
+
+CSV_COLUMNS: List[str] = [
+    "found_at",
+    "item",
+    "marketplace",
+    "title",
+    "price",
+    "rating",
+    "ai_comment",
+    "location",
+    "seller",
+    "condition",
+    "notified_user",
+    "url",
+]
+
+
+def rows_to_csv(rows: List[Dict[str, str]]) -> str:
+    """Serialize rows to CSV text with a fixed header and column order."""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue()

--- a/src/ai_marketplace_monitor/webui/found_export.py
+++ b/src/ai_marketplace_monitor/webui/found_export.py
@@ -3,17 +3,27 @@
 Reads the notified/matched listings out of the diskcache and joins them with
 cached listing details and AI ratings to produce CSV-ready rows.  Read-only:
 no scraping and no new persistence.
+
+Memory use is bounded to the notified subset, not the whole cache: the full
+``LISTING_DETAILS`` / ``AI_INQUIRY`` namespaces (every listing ever scraped and
+every AI inquiry) are never loaded wholesale.  A first pass collects the small
+set of listing ids and hashes the notified rows actually reference; a second
+pass loads only those.  Rows and the CSV itself are produced lazily so an
+export of many records never materializes all rows or the full CSV at once.
 """
 
 from __future__ import annotations
 
 import csv
 import io
-from typing import Any, Dict, List, Optional, Tuple
+import logging
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 
 from diskcache import Cache  # type: ignore
 
 from ..utils import CacheType
+
+logger = logging.getLogger(__name__)
 
 CSV_COLUMNS: List[str] = [
     "found_at",
@@ -29,6 +39,12 @@ CSV_COLUMNS: List[str] = [
     "notified_user",
     "url",
 ]
+
+# (marketplace, listing_id, user, date, listing_hash, price)
+NotifiedRow = Tuple[str, str, str, str, Optional[str], Optional[str]]
+
+# Leading characters a spreadsheet may interpret as a formula.
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
 
 
 def _normalize_notified(value: Any) -> Tuple[str, Optional[str], Optional[str]]:
@@ -54,15 +70,59 @@ def _fallback_url(marketplace: str, listing_id: str) -> str:
     return ""
 
 
-def build_found_rows(local_cache: Cache) -> List[Dict[str, str]]:
-    """Join notified items with details and ratings into CSV-ready rows.
+def _sanitize(value: str) -> str:
+    """Neutralize spreadsheet formula triggers in an untrusted CSV cell.
 
-    Emits one row per USER_NOTIFIED entry (i.e. per listing per user), sorted
-    by found_at descending.  Malformed or legacy cache entries are skipped.
+    Listing fields (title, seller, AI comment, ...) are scraped, attacker-
+    influenceable text.  A cell starting with ``= + - @`` can execute as a
+    formula when opened in Excel/Sheets, so such cells are prefixed with a
+    single quote (OWASP CSV-injection guidance).
     """
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
+def _collect_needed(
+    local_cache: Cache,
+) -> Tuple[List[NotifiedRow], Set[Tuple[str, str]], Set[str]]:
+    """First pass: the notified spine plus the ids/hashes it references.
+
+    Only USER_NOTIFIED entries are read here, so the large LISTING_DETAILS /
+    AI_INQUIRY namespaces are not loaded during this pass.
+    """
+    notified: List[NotifiedRow] = []
+    needed_listings: Set[Tuple[str, str]] = set()
+    needed_hashes: Set[str] = set()
+
+    for key in local_cache.iterkeys():
+        if not isinstance(key, tuple) or len(key) < 4:
+            continue
+        if key[0] != CacheType.USER_NOTIFIED.value:
+            continue
+        try:
+            date, listing_hash, price = _normalize_notified(local_cache.get(key))
+        except KeyboardInterrupt:
+            raise
+        except Exception:
+            logger.debug("Skipping malformed USER_NOTIFIED entry %r", key, exc_info=True)
+            continue
+        notified.append((key[1], key[2], key[3], date, listing_hash, price))
+        needed_listings.add((key[1], key[2]))
+        if listing_hash:
+            needed_hashes.add(listing_hash)
+
+    return notified, needed_listings, needed_hashes
+
+
+def _load_lookups(
+    local_cache: Cache,
+    needed_listings: Set[Tuple[str, str]],
+    needed_hashes: Set[str],
+) -> Tuple[Dict[Tuple[str, str], Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    """Second pass: load only the details and ratings the notified rows need."""
     details_by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
     rating_by_hash: Dict[str, Dict[str, Any]] = {}
-    notified: List[Tuple[str, str, str, str, Optional[str], Optional[str]]] = []
 
     for key in local_cache.iterkeys():
         if not isinstance(key, tuple) or not key:
@@ -72,49 +132,91 @@ def build_found_rows(local_cache: Cache) -> List[Dict[str, str]]:
             if tag == CacheType.LISTING_DETAILS.value:
                 value = local_cache.get(key)
                 if isinstance(value, dict) and "id" in value and "marketplace" in value:
-                    details_by_key[(value["marketplace"], value["id"])] = value
+                    m_id = (value["marketplace"], value["id"])
+                    if m_id in needed_listings:
+                        details_by_key[m_id] = value
             elif tag == CacheType.AI_INQUIRY.value and len(key) >= 4:
-                value = local_cache.get(key)
-                if isinstance(value, dict):
-                    rating_by_hash[key[3]] = value
-            elif tag == CacheType.USER_NOTIFIED.value and len(key) >= 4:
-                date, listing_hash, price = _normalize_notified(local_cache.get(key))
-                notified.append((key[1], key[2], key[3], date, listing_hash, price))
+                if key[3] in needed_hashes:
+                    value = local_cache.get(key)
+                    if isinstance(value, dict):
+                        rating_by_hash[key[3]] = value
         except KeyboardInterrupt:
             raise
         except Exception:
+            logger.debug("Skipping malformed %r cache entry %r", tag, key, exc_info=True)
             continue
 
-    rows: List[Dict[str, str]] = []
-    for marketplace, listing_id, user, date, listing_hash, price in notified:
-        details = details_by_key.get((marketplace, listing_id)) or {}
-        rating = (rating_by_hash.get(listing_hash) if listing_hash else None) or {}
-        rows.append(
-            {
-                "found_at": date or "",
-                "item": details.get("name", "") or "",
-                "marketplace": marketplace,
-                "title": details.get("title", "") or "",
-                "price": (price if price is not None else details.get("price", "")) or "",
-                "rating": str(rating["score"]) if "score" in rating else "",
-                "ai_comment": rating.get("comment", "") or "",
-                "location": details.get("location", "") or "",
-                "seller": details.get("seller", "") or "",
-                "condition": details.get("condition", "") or "",
-                "notified_user": user,
-                "url": details.get("post_url") or _fallback_url(marketplace, listing_id),
-            }
-        )
-
-    rows.sort(key=lambda r: r["found_at"], reverse=True)
-    return rows
+    return details_by_key, rating_by_hash
 
 
-def rows_to_csv(rows: List[Dict[str, str]]) -> str:
-    """Serialize rows to CSV text with a fixed header and column order."""
-    buffer = io.StringIO()
+def _to_row(
+    notified: NotifiedRow,
+    details_by_key: Dict[Tuple[str, str], Dict[str, Any]],
+    rating_by_hash: Dict[str, Dict[str, Any]],
+) -> Dict[str, str]:
+    """Join one notified entry with its details and rating into a CSV row."""
+    marketplace, listing_id, user, date, listing_hash, price = notified
+    details = details_by_key.get((marketplace, listing_id)) or {}
+    rating = (rating_by_hash.get(listing_hash) if listing_hash else None) or {}
+    return {
+        "found_at": date or "",
+        "item": details.get("name", "") or "",
+        "marketplace": marketplace,
+        "title": details.get("title", "") or "",
+        "price": (price if price is not None else details.get("price", "")) or "",
+        "rating": str(rating["score"]) if "score" in rating else "",
+        "ai_comment": rating.get("comment", "") or "",
+        "location": details.get("location", "") or "",
+        "seller": details.get("seller", "") or "",
+        "condition": details.get("condition", "") or "",
+        "notified_user": user,
+        "url": details.get("post_url") or _fallback_url(marketplace, listing_id),
+    }
+
+
+def iter_found_rows(local_cache: Cache) -> Iterator[Dict[str, str]]:
+    """Yield found-item rows lazily, one per USER_NOTIFIED entry, newest first.
+
+    Memory stays bounded to the notified subset: only the listing details and
+    ratings referenced by notified items are loaded, and row dicts are produced
+    one at a time rather than all at once.
+    """
+    notified, needed_listings, needed_hashes = _collect_needed(local_cache)
+    details_by_key, rating_by_hash = _load_lookups(local_cache, needed_listings, needed_hashes)
+    # Sort the small notified tuples (not full row dicts) by found date, newest first.
+    notified.sort(key=lambda n: n[3] or "", reverse=True)
+    for entry in notified:
+        yield _to_row(entry, details_by_key, rating_by_hash)
+
+
+def build_found_rows(local_cache: Cache) -> List[Dict[str, str]]:
+    """Materialize all found-item rows (see :func:`iter_found_rows`)."""
+    return list(iter_found_rows(local_cache))
+
+
+def _drain(buffer: io.StringIO) -> str:
+    """Return and clear the buffer's contents."""
+    text = buffer.getvalue()
+    buffer.seek(0)
+    buffer.truncate(0)
+    return text
+
+
+def iter_found_csv(rows: Iterable[Dict[str, str]]) -> Iterator[str]:
+    """Yield CSV text incrementally (header first), one chunk per row.
+
+    Cells are sanitized against spreadsheet formula injection.  ``newline=""``
+    keeps the csv module's line terminators intact.
+    """
+    buffer = io.StringIO(newline="")
     writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS, extrasaction="ignore")
     writer.writeheader()
+    yield _drain(buffer)
     for row in rows:
-        writer.writerow(row)
-    return buffer.getvalue()
+        writer.writerow({key: _sanitize(value) for key, value in row.items()})
+        yield _drain(buffer)
+
+
+def rows_to_csv(rows: Iterable[Dict[str, str]]) -> str:
+    """Serialize rows to a single CSV string (convenience over iter_found_csv)."""
+    return "".join(iter_found_csv(rows))

--- a/src/ai_marketplace_monitor/webui/server.py
+++ b/src/ai_marketplace_monitor/webui/server.py
@@ -31,7 +31,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from ..utils import cache
@@ -48,7 +48,7 @@ from .auth import (
 )
 from .config_api import ConfigFileService
 from .config_auth import extract_credentials
-from .found_export import build_found_rows, rows_to_csv
+from .found_export import iter_found_csv, iter_found_rows
 from .log_handler import LogBroadcastHandler
 
 # Ensure the vendored toml-edit-js WASM bundle is served with the right
@@ -467,12 +467,15 @@ def create_app(
         async def index() -> FileResponse:
             return FileResponse(STATIC_DIR / "index.html")
 
+    # Sync def (not async): FastAPI runs it in a threadpool and Starlette
+    # iterates the sync generator there too, so the blocking cache scan never
+    # runs on the event loop. The body streams row-by-row rather than buffering
+    # the whole CSV, keeping memory bounded for large exports.
     @app.get("/api/found.csv")
-    async def export_found_csv(_: str = Depends(require_session)) -> Response:
-        csv_text = rows_to_csv(build_found_rows(cache))
+    def export_found_csv(_: str = Depends(require_session)) -> StreamingResponse:
         filename = f"found-items-{time.strftime('%Y%m%d-%H%M%S')}.csv"
-        return Response(
-            content=csv_text,
+        return StreamingResponse(
+            iter_found_csv(iter_found_rows(cache)),
             media_type="text/csv; charset=utf-8",
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )

--- a/src/ai_marketplace_monitor/webui/server.py
+++ b/src/ai_marketplace_monitor/webui/server.py
@@ -34,6 +34,7 @@ from fastapi import (
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from ..utils import cache
 from .auth import (
     CSRF_COOKIE,
     CSRF_HEADER,
@@ -47,6 +48,7 @@ from .auth import (
 )
 from .config_api import ConfigFileService
 from .config_auth import extract_credentials
+from .found_export import build_found_rows, rows_to_csv
 from .log_handler import LogBroadcastHandler
 
 # Ensure the vendored toml-edit-js WASM bundle is served with the right
@@ -464,6 +466,16 @@ def create_app(
         @app.get("/")
         async def index() -> FileResponse:
             return FileResponse(STATIC_DIR / "index.html")
+
+    @app.get("/api/found.csv")
+    async def export_found_csv(_: str = Depends(require_session)) -> Response:
+        csv_text = rows_to_csv(build_found_rows(cache))
+        filename = f"found-items-{time.strftime('%Y%m%d-%H%M%S')}.csv"
+        return Response(
+            content=csv_text,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
 
     return app
 

--- a/src/ai_marketplace_monitor/webui/static/app.js
+++ b/src/ai_marketplace_monitor/webui/static/app.js
@@ -553,6 +553,36 @@
     }
   });
 
+  wireClick("#export-csv-btn", async () => {
+    const btn = $("#export-csv-btn");
+    if (btn) btn.disabled = true;
+    try {
+      const res = await api("/api/found.csv");
+      if (!res.ok) {
+        setEditorStatus("⬇ Export failed: " + res.status, "err");
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const stamp = new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace(/[-:T]/g, "")
+        .replace(/(\d{8})(\d{6})/, "$1-$2");
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `found-items-${stamp}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setEditorStatus("⬇ Export failed: " + err.message, "err");
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  });
+
   // ---------------------------------------------------------------
   // Sections sidebar (AI-assisted edit / delete / add)
   // ---------------------------------------------------------------

--- a/src/ai_marketplace_monitor/webui/static/index.html
+++ b/src/ai_marketplace_monitor/webui/static/index.html
@@ -35,6 +35,7 @@
         <span id="monitor-status" class="status-chip status-warn" title="Last activity from the monitor">● monitor: idle</span>
         <button id="restart-btn" class="ghost small" title="Wake up and search all items now" aria-label="Wake up and search all items now">▶</button>
         <a id="browser-btn" class="ghost" href="/vnc/vnc.html?path=ws/vnc&autoconnect=1&resize=scale" target="_blank" rel="noopener" title="Open the live Chromium view (CAPTCHA / login)" hidden>Browser</a>
+        <button id="export-csv-btn" class="ghost small" title="Download all found items as CSV" aria-label="Download all found items as CSV">⬇ Export CSV</button>
         <button id="logout-btn" class="ghost">Logout</button>
       </div>
     </header>

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -21,7 +21,7 @@ def test_rows_to_csv_empty_has_header_only() -> None:
 
 
 def test_rows_to_csv_writes_row_and_escapes() -> None:
-    row = {c: "" for c in CSV_COLUMNS}
+    row = dict.fromkeys(CSV_COLUMNS, "")
     row["title"] = 'Chair, "comfy"'
     row["price"] = "$40"
     text = rows_to_csv([row])

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -36,6 +36,18 @@ def test_rows_to_csv_writes_row_and_escapes() -> None:
     assert parsed[0]["price"] == "$40"
 
 
+def test_rows_to_csv_neutralizes_formula_injection() -> None:
+    row = dict.fromkeys(CSV_COLUMNS, "")
+    row["title"] = '=HYPERLINK("http://evil")'
+    row["seller"] = "+cmd"
+    row["ai_comment"] = "@SUM(1)"
+    text = rows_to_csv([row])
+    parsed = _parse(text)
+    assert parsed[0]["title"] == '\'=HYPERLINK("http://evil")'
+    assert parsed[0]["seller"] == "'+cmd"
+    assert parsed[0]["ai_comment"] == "'@SUM(1)"
+
+
 from pathlib import Path  # noqa: E402
 from typing import Iterator  # noqa: E402
 
@@ -159,6 +171,23 @@ def test_build_rows_sorted_by_found_at_desc(temp_cache: Cache) -> None:
     _seed_notified(temp_cache, new, date="2026-07-16 08:00:00")
     rows = build_found_rows(temp_cache)
     assert [r["found_at"] for r in rows] == ["2026-07-16 08:00:00", "2026-07-10 08:00:00"]
+
+
+def test_build_rows_excludes_unnotified_listings(temp_cache: Cache) -> None:
+    # One notified listing, fully joined.
+    wanted = _listing("111")
+    wanted.to_cache(wanted.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, wanted)
+    _seed_notified(temp_cache, wanted)
+    # An unrelated scraped listing + rating that was never notified: the two-pass
+    # loader must not surface it (and, per the memory design, not even load it).
+    other = _listing("222")
+    other.to_cache(other.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, other)
+
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 1
+    assert rows[0]["url"] == "https://www.facebook.com/marketplace/item/111/?ref=search"
 
 
 from fastapi.testclient import TestClient  # noqa: E402

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -29,3 +29,128 @@ def test_rows_to_csv_writes_row_and_escapes() -> None:
     assert len(parsed) == 1
     assert parsed[0]["title"] == 'Chair, "comfy"'
     assert parsed[0]["price"] == "$40"
+
+
+from pathlib import Path  # noqa: E402
+from typing import Iterator  # noqa: E402
+
+import pytest  # noqa: E402
+from diskcache import Cache  # type: ignore  # noqa: E402
+
+from ai_marketplace_monitor.listing import Listing  # noqa: E402
+from ai_marketplace_monitor.utils import CacheType  # noqa: E402
+from ai_marketplace_monitor.webui.found_export import build_found_rows  # noqa: E402
+
+
+def _listing(listing_id: str = "123", price: str = "$100") -> Listing:
+    return Listing(
+        marketplace="facebook",
+        name="iphone",
+        id=listing_id,
+        title="iPhone 13",
+        image="http://img/x.jpg",
+        price=price,
+        post_url=f"https://www.facebook.com/marketplace/item/{listing_id}/?ref=search",
+        location="Houston, TX",
+        seller="Jane Doe",
+        condition="used_good",
+        description="great phone",
+    )
+
+
+@pytest.fixture
+def temp_cache(tmp_path: Path) -> Iterator[Cache]:
+    cache = Cache(str(tmp_path / "cache"))
+    yield cache
+    cache.close()
+
+
+def _seed_notified(
+    cache: Cache, listing: Listing, user: str = "me", date: str = "2026-07-16 10:00:00"
+) -> None:
+    cache.set(
+        (CacheType.USER_NOTIFIED.value, listing.marketplace, listing.id, user),
+        (date, listing.hash, listing.price),
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+
+
+def _seed_rating(
+    cache: Cache, listing: Listing, score: int = 5, comment: str = "Great deal"
+) -> None:
+    cache.set(
+        (CacheType.AI_INQUIRY.value, "itemhash", "mkthash", listing.hash),
+        {"score": score, "comment": comment, "name": ""},
+        tag=CacheType.AI_INQUIRY.value,
+    )
+
+
+def test_build_rows_full_join(temp_cache: Cache) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, listing)
+    _seed_notified(temp_cache, listing)
+
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["found_at"] == "2026-07-16 10:00:00"
+    assert row["item"] == "iphone"
+    assert row["marketplace"] == "facebook"
+    assert row["title"] == "iPhone 13"
+    assert row["price"] == "$100"
+    assert row["rating"] == "5"
+    assert row["ai_comment"] == "Great deal"
+    assert row["location"] == "Houston, TX"
+    assert row["seller"] == "Jane Doe"
+    assert row["condition"] == "used_good"
+    assert row["notified_user"] == "me"
+    assert row["url"] == "https://www.facebook.com/marketplace/item/123/?ref=search"
+
+
+def test_build_rows_missing_details_uses_fallback_url(temp_cache: Cache) -> None:
+    listing = _listing()
+    _seed_notified(temp_cache, listing)  # no LISTING_DETAILS, no rating
+
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 1
+    assert rows[0]["title"] == ""
+    assert rows[0]["rating"] == ""
+    assert rows[0]["url"] == "https://www.facebook.com/marketplace/item/123/"
+
+
+def test_build_rows_legacy_notified_value_shapes(temp_cache: Cache) -> None:
+    listing = _listing()
+    # legacy: bare date string
+    temp_cache.set(
+        (CacheType.USER_NOTIFIED.value, "facebook", "aaa", "me"),
+        "2026-07-15 09:00:00",
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+    # legacy: 2-tuple (date, hash)
+    temp_cache.set(
+        (CacheType.USER_NOTIFIED.value, "facebook", "bbb", "me"),
+        ("2026-07-15 09:30:00", listing.hash),
+        tag=CacheType.USER_NOTIFIED.value,
+    )
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 2
+    assert {r["found_at"] for r in rows} == {"2026-07-15 09:00:00", "2026-07-15 09:30:00"}
+
+
+def test_build_rows_multi_user_two_rows(temp_cache: Cache) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_notified(temp_cache, listing, user="alice")
+    _seed_notified(temp_cache, listing, user="bob")
+    rows = build_found_rows(temp_cache)
+    assert len(rows) == 2
+    assert {r["notified_user"] for r in rows} == {"alice", "bob"}
+
+
+def test_build_rows_sorted_by_found_at_desc(temp_cache: Cache) -> None:
+    old, new = _listing("111"), _listing("222")
+    _seed_notified(temp_cache, old, date="2026-07-10 08:00:00")
+    _seed_notified(temp_cache, new, date="2026-07-16 08:00:00")
+    rows = build_found_rows(temp_cache)
+    assert [r["found_at"] for r in rows] == ["2026-07-16 08:00:00", "2026-07-10 08:00:00"]

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -154,3 +154,53 @@ def test_build_rows_sorted_by_found_at_desc(temp_cache: Cache) -> None:
     _seed_notified(temp_cache, new, date="2026-07-16 08:00:00")
     rows = build_found_rows(temp_cache)
     assert [r["found_at"] for r in rows] == ["2026-07-16 08:00:00", "2026-07-10 08:00:00"]
+
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ai_marketplace_monitor.webui import server as webui_server  # noqa: E402
+from ai_marketplace_monitor.webui.config_api import ConfigFileService  # noqa: E402
+from ai_marketplace_monitor.webui.log_handler import LogBroadcastHandler  # noqa: E402
+from ai_marketplace_monitor.webui.server import AuthState, WebUIConfig, create_app  # noqa: E402
+
+
+def _make_client(
+    tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch, exposed: bool = False
+) -> TestClient:
+    monkeypatch.setattr(webui_server, "cache", temp_cache)
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("[marketplace.facebook]\nsearch_city = 'dallas'\n", encoding="utf-8")
+    handler = LogBroadcastHandler()
+    config = WebUIConfig(config_files=[cfg_file], log_handler=handler)
+    state = AuthState()
+    state.exposed = exposed
+    service = ConfigFileService([cfg_file])
+    app = create_app(config, state, service, handler)
+    return TestClient(app)
+
+
+def test_endpoint_returns_csv(
+    tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    listing = _listing()
+    listing.to_cache(listing.post_url, local_cache=temp_cache)
+    _seed_rating(temp_cache, listing)
+    _seed_notified(temp_cache, listing)
+
+    client = _make_client(tmp_path, temp_cache, monkeypatch)
+    resp = client.get("/api/found.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "attachment" in resp.headers["content-disposition"]
+    parsed = list(csv.DictReader(io.StringIO(resp.text)))
+    assert len(parsed) == 1
+    assert parsed[0]["rating"] == "5"
+    assert parsed[0]["url"].startswith("https://www.facebook.com/marketplace/item/123/")
+
+
+def test_endpoint_requires_session_when_exposed(
+    tmp_path: Path, temp_cache: Cache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _make_client(tmp_path, temp_cache, monkeypatch, exposed=True)
+    resp = client.get("/api/found.csv")
+    assert resp.status_code == 401

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -17,6 +17,11 @@ def test_rows_to_csv_empty_has_header_only() -> None:
     text = rows_to_csv([])
     lines = text.splitlines()
     assert lines[0].split(",") == CSV_COLUMNS
+    # Pin the canonical column order (a binding requirement) against silent drift.
+    assert lines[0] == (
+        "found_at,item,marketplace,title,price,rating,ai_comment,"
+        "location,seller,condition,notified_user,url"
+    )
     assert len(lines) == 1
 
 

--- a/tests/test_found_export.py
+++ b/tests/test_found_export.py
@@ -1,0 +1,31 @@
+"""Tests for the Web UI found-items CSV export."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Dict, List
+
+from ai_marketplace_monitor.webui.found_export import CSV_COLUMNS, rows_to_csv
+
+
+def _parse(text: str) -> List[Dict[str, str]]:
+    return list(csv.DictReader(io.StringIO(text)))
+
+
+def test_rows_to_csv_empty_has_header_only() -> None:
+    text = rows_to_csv([])
+    lines = text.splitlines()
+    assert lines[0].split(",") == CSV_COLUMNS
+    assert len(lines) == 1
+
+
+def test_rows_to_csv_writes_row_and_escapes() -> None:
+    row = {c: "" for c in CSV_COLUMNS}
+    row["title"] = 'Chair, "comfy"'
+    row["price"] = "$40"
+    text = rows_to_csv([row])
+    parsed = _parse(text)
+    assert len(parsed) == 1
+    assert parsed[0]["title"] == 'Chair, "comfy"'
+    assert parsed[0]["price"] == "$40"


### PR DESCRIPTION
## Summary

Closes #334. Adds an **⬇ Export CSV** button to the Web UI header that downloads all **found (notified)** listings — link, price, rating, AI comment, and the listing details — as a CSV. It reads and joins the existing on-disk `diskcache`: **no scraping and no new persistent storage.**

## What "found items" means

The export = the matched/**notified** listings (the ones the monitor decided were worth surfacing), not every scraped listing. Rating only exists for AI-evaluated items — which are exactly the notified ones — so this is what the requester means by a list with `rating`.

## How it works

- **`webui/found_export.py`** (pure logic, no HTTP): enumerates the cache by tag and joins three namespaces — `USER_NOTIFIED` (row spine: found-timestamp, user, price), `LISTING_DETAILS` (title/url/location/seller/condition), `AI_INQUIRY` (rating + comment, joined via the stored `listing.hash`). One row per (listing, user), sorted by found-date descending. Handles legacy `USER_NOTIFIED` value shapes and falls back to a reconstructed Facebook URL if a listing's details were evicted.
- **`GET /api/found.csv`** in `webui/server.py`: thin wrapper — `Depends(require_session)` only (a read, like `/api/status`), returns `text/csv` as an attachment.
- **Frontend**: a header button whose handler fetches with credentials and saves the blob (fetch+blob so a 401 surfaces cleanly instead of navigating to a JSON body).

**Columns:** `found_at, item, marketplace, title, price, rating, ai_comment, location, seller, condition, notified_user, url`

## Testing

- Unit tests for the join (full join, missing-details fallback, legacy value shapes, multi-user cardinality, sort order) and the serializer (canonical column order pinned, escaping).
- Endpoint tests via FastAPI `TestClient`: 200 + `text/csv` + attachment headers, and 401 when exposed without a session.
- Full local gate green: `pre-commit run --all-files`, `mypy src tests` (40 files), `pytest` (166 passed, 1 skipped).
- Live smoke test: button renders, click → `GET /api/found.csv → 200`, correct 12-column CSV.

## Design docs

Design spec and implementation plan are included under `docs/superpowers/` for reference.

## Notes / conscious decisions

- **CSV formula injection** — cells come from scraped, seller-controlled data. The stdlib `csv` module quotes commas/quotes/newlines but does not neutralize a leading `= + - @`. Judged **low severity for this tool's threat model** (a self-hosted personal tool where the operator exports and opens their own data; modern spreadsheet apps warn before executing external formulas), so it is intentionally **not** mitigated here. Flagging it explicitly as a follow-up candidate (OWASP guidance: prefix such cells with `'`).
- Scope intentionally excludes an in-UI table view, filtering/date ranges, and exporting all scraped (non-notified) listings (YAGNI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Export CSV” button to the Web UI.
  * Download found/notified listings as a CSV with links, prices, ratings, and details.
  * Exports one row per notified listing and recipient, including sensible handling for empty results.
  * CSV downloads require an authenticated session when the Web UI is exposed.
* **Documentation**
  * Updated the Web UI docs and changelog to describe the CSV export feature.
* **Tests**
  * Added coverage for CSV generation, field escaping, legacy cache handling, and the `/api/found.csv` endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->