### PR TITLE
chore: release 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-17
+
 ### Added
 - Option `sort_by` to order Facebook search results by `suggested`, `new` (newest first), `price_ascend`, `price_descend`, or `distance_ascend` ([#323](https://github.com/BoPeng/ai-marketplace-monitor/issues/323))
 - Web UI "Export CSV" button that downloads all found (notified) listings with link, price, rating, and details ([#334](https://github.com/BoPeng/ai-marketplace-monitor/issues/334))
-
-## [0.10.2]
-
-### Added
 - Docker image bundling Xvfb + Playwright Chromium + noVNC, with a "Browser" button in the web UI that exposes the live Chromium session for solving Facebook CAPTCHA / interactive logins ([#310](https://github.com/BoPeng/ai-marketplace-monitor/issues/310))
 - GitHub Actions workflow publishing multi-arch (amd64/arm64) images to `ghcr.io/bopeng/ai-marketplace-monitor`
 


### PR DESCRIPTION
Finalizes the CHANGELOG for the **0.10.2** release.

`0.10.2` was bumped in `pyproject.toml` earlier (for the Docker/noVNC work) but never tagged or published — PyPI's latest is `0.10.1`. So this becomes the next release, covering everything since 0.10.1:

**Added**
- `sort_by` option for Facebook search ordering ([#323](https://github.com/BoPeng/ai-marketplace-monitor/issues/323) / #340)
- Web UI "Export CSV" of found items ([#334](https://github.com/BoPeng/ai-marketplace-monitor/issues/334) / #341)
- Docker image with embedded noVNC browser view (#310)
- Multi-arch image publishing workflow

plus the Fixed / Documentation entries already listed under 0.10.2.

`pyproject.toml` is already at `0.10.2`. After this merges, the release is cut by creating the **GitHub Release for tag `v0.10.2`**, which triggers the PyPI publish workflow.

Note (not addressed here, out of scope): `.bumpversion.cfg` (`current_version = 0.10.1`), `CITATION.cff` (`0.1.0`), and the CHANGELOG compare-links (`v0.1.0`) are stale — they haven't tracked releases for a while. Left alone since they're not part of the actual release flow and CITATION/DOI metadata is sensitive to change blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the 0.10.2 changelog with a dated release header.
  * Consolidated additions under a single section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->