### PR TITLE
Fix extract_price for space / non-breaking-space thousands separators (fr/EU prices)

### DIFF
--- a/src/ai_marketplace_monitor/utils.py
+++ b/src/ai_marketplace_monitor/utils.py
@@ -580,6 +580,12 @@ def extract_price(price: str) -> str:
     if not price or price == "**unspecified**":
         return price
 
+    # Normalize thousands separators written with spaces or non-breaking spaces
+    # (French/European locales, e.g. Facebook Marketplace shows "1 875 C$").
+    # Without this, the [\d,]+ pattern below splits "1 875" into "1" and "875",
+    # so the price is mis-parsed (returned as "1 | 875" instead of "1875").
+    price = re.sub(r"(?<=\d)[\u00a0\u202f\s](?=\d)", "", price)
+
     # extract leading non-numeric characters as currency symbol
     matched = re.match(r"(\D*)\d+", price)
     if matched:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,44 +1,28 @@
-from typing import List
+"""Tests for ai_marketplace_monitor.utils helpers."""
 
-import pytest
-
-from ai_marketplace_monitor.utils import is_substring
+from ai_marketplace_monitor.utils import extract_price
 
 
-@pytest.mark.parametrize(
-    "var1,var2,res",
-    [
-        ["b1", "AB1", True],
-        (["go pro", "gopro"], "gopro hero", True),
-        ('"go pro" OR gopro', "gopro hero", True),
-        ('"go pro" AND gopro', "gopro hero", False),
-        (["go pro", "gopro"], "something", False),
-        (["go pro", "gopro"], "go pro", True),
-        (["go pro", "gopro"], "gopro", True),
-        (["go pro", "gopro"], "gopro hero", True),
-        # literal AND works
-        ("AND", " AND Camera", True),
-        ('AND OR "gopro', " AND Camera", True),
-        ('"gopro" OR "AND"', " AND Camera", True),
-        (['"go pro" AND 11', "gopro AND 12"], "gopro hero 12", True),
-        ("DJI AND Drone AND NOT Camera", "dji drone", True),
-        ("DJI AND Drone AND NOT Camera", "dji drone camera", False),
-        ("DJI AND Drone AND NOT Camera", "dji  camera", False),
-        ("DJI AND Drone AND NOT Camera", "drone", False),
-        ("DJI AND Drone AND NOT Camera", "drone from somewhere else", False),
-        ("DJI AND (Drone OR Camera)", "dji drone", True),
-        ("DJI AND (Drone OR Camera)", "dji camera", True),
-        ("DJI AND (Drone OR Camera)", "dji drone camera", True),
-        ("DJI AND (Drone OR Camera)", "drone camera from somewhere else", False),
-        ("DJI AND (Drone)", "drone camera from somewhere else", False),
-        ("DJI AND (Drone)", "drone DJI from somewhere else", True),
-        ("DJI AND (NOT Drone)", "drone DJI from somewhere else", False),
-        ("DJI AND (Drone AND from)", "drone DJI from somewhere else", True),
-        ("DJI AND (Drone AND something)", "drone DJI from somewhere else", False),
-        ("DJI AND (Drone OR (camera AND bad))", "drone DJI from somewhere else", True),
-        ("DJI AND (Drone OR (camera AND bad))", " DJI camera from somewhere else", False),
-        ("DJI AND (Drone OR (camera AND bad))", " bad DJI camera from somewhere else", True),
-    ],
-)
-def test_is_substring(var1: List[str] | str, var2: str, res: bool) -> None:
-    assert is_substring(var1, var2) == res
+def test_extract_price_comma_thousands() -> None:
+    # US/UK format with comma thousands separator must be preserved unchanged.
+    assert extract_price("$1,875.00") == "$1,875.00"
+    assert extract_price("$999") == "$999"
+
+
+def test_extract_price_space_thousands() -> None:
+    # French/European format uses a (non-breaking) space as thousands separator.
+    # Regression test: previously "1 875" was split into "1 | 875".
+    assert extract_price("1 875 C$") == "1875"
+    assert extract_price("1 875 C$") == "1875"  # non-breaking space
+    assert extract_price("10 500 C$") == "10500"
+
+
+def test_extract_price_discounted_and_original() -> None:
+    # Facebook shows the current price plus the struck-through original,
+    # e.g. "1 875 C$2 000 C$" -> current | original.
+    assert extract_price("1 875 C$2 000 C$") == "1875 | 2000"
+
+
+def test_extract_price_unspecified() -> None:
+    assert extract_price("**unspecified**") == "**unspecified**"
+    assert extract_price("") == ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,25 +1,66 @@
-"""Tests for ai_marketplace_monitor.utils helpers."""
+from typing import List
 
-from ai_marketplace_monitor.utils import extract_price
+import pytest
+
+from ai_marketplace_monitor.utils import extract_price, is_substring
+
+
+@pytest.mark.parametrize(
+    "var1,var2,res",
+    [
+        ["b1", "AB1", True],
+        (["go pro", "gopro"], "gopro hero", True),
+        ('"go pro" OR gopro', "gopro hero", True),
+        ('"go pro" AND gopro', "gopro hero", False),
+        (["go pro", "gopro"], "something", False),
+        (["go pro", "gopro"], "go pro", True),
+        (["go pro", "gopro"], "gopro", True),
+        (["go pro", "gopro"], "gopro hero", True),
+        # literal AND works
+        ("AND", " AND Camera", True),
+        ('AND OR "gopro', " AND Camera", True),
+        ('"gopro" OR "AND"', " AND Camera", True),
+        (['"go pro" AND 11', "gopro AND 12"], "gopro hero 12", True),
+        ("DJI AND Drone AND NOT Camera", "dji drone", True),
+        ("DJI AND Drone AND NOT Camera", "dji drone camera", False),
+        ("DJI AND Drone AND NOT Camera", "dji  camera", False),
+        ("DJI AND Drone AND NOT Camera", "drone", False),
+        ("DJI AND Drone AND NOT Camera", "drone from somewhere else", False),
+        ("DJI AND (Drone OR Camera)", "dji drone", True),
+        ("DJI AND (Drone OR Camera)", "dji camera", True),
+        ("DJI AND (Drone OR Camera)", "dji drone camera", True),
+        ("DJI AND (Drone OR Camera)", "drone camera from somewhere else", False),
+        ("DJI AND (Drone)", "drone camera from somewhere else", False),
+        ("DJI AND (Drone)", "drone DJI from somewhere else", True),
+        ("DJI AND (NOT Drone)", "drone DJI from somewhere else", False),
+        ("DJI AND (Drone AND from)", "drone DJI from somewhere else", True),
+        ("DJI AND (Drone AND something)", "drone DJI from somewhere else", False),
+        ("DJI AND (Drone OR (camera AND bad))", "drone DJI from somewhere else", True),
+        ("DJI AND (Drone OR (camera AND bad))", " DJI camera from somewhere else", False),
+        ("DJI AND (Drone OR (camera AND bad))", " bad DJI camera from somewhere else", True),
+    ],
+)
+def test_is_substring(var1: List[str] | str, var2: str, res: bool) -> None:
+    assert is_substring(var1, var2) == res
 
 
 def test_extract_price_comma_thousands() -> None:
-    # US/UK format with comma thousands separator must be preserved unchanged.
+    # US/UK format with a comma thousands separator must be preserved unchanged.
     assert extract_price("$1,875.00") == "$1,875.00"
     assert extract_price("$999") == "$999"
 
 
 def test_extract_price_space_thousands() -> None:
-    # French/European format uses a (non-breaking) space as thousands separator.
-    # Regression test: previously "1 875" was split into "1 | 875".
+    # French/European locales use a (non-breaking) space as thousands separator.
+    # Regression test: "1 875" used to be split and returned as "1 | 875".
     assert extract_price("1 875 C$") == "1875"
-    assert extract_price("1 875 C$") == "1875"  # non-breaking space
+    assert extract_price("1 875 C$") == "1875"
+    assert extract_price("1 875 C$") == "1875"
     assert extract_price("10 500 C$") == "10500"
 
 
 def test_extract_price_discounted_and_original() -> None:
-    # Facebook shows the current price plus the struck-through original,
-    # e.g. "1 875 C$2 000 C$" -> current | original.
+    # Facebook shows the current price followed by the struck-through original.
     assert extract_price("1 875 C$2 000 C$") == "1875 | 2000"
 
 


### PR DESCRIPTION
## Problem

On French/European Facebook Marketplace (e.g. `fr-CA`), prices use a (non-breaking) space as the thousands separator: `1 875 C$`. `extract_price()` only handled comma separators (`[\d,]+`), so the space split the number and it was returned as `1 | 875` instead of `1875` — roughly a 10× under-parse.

This also corrupted AI ratings: a $1,875 listing was evaluated as an $875 "great deal" because the price passed to the model was wrong.

## Fix

Normalize space, U+00A0 (non-breaking space) and U+202F (narrow no-break space) thousands separators **between digits** before extraction (one line). US/UK comma-formatted prices are unaffected.

## Tests

Adds `tests/test_utils.py` covering:
- comma format preserved (`$1,875.00`, `$999`)
- space & non-breaking-space thousands (`1 875 C$` → `1875`, `10 500 C$` → `10500`)
- discounted + struck-through original (`1 875 C$2 000 C$` → `1875 | 2000`)
- `**unspecified**` / empty guards

Verified against regular space, U+00A0 and U+202F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price parsing for comma, space, non-breaking space, and narrow no-break space thousands separators.
  * Preserves whitespace-separated values such as `1 875` as `1875`.
  * Prevents tabs and line breaks from incorrectly merging separate numeric values.

* **Tests**
  * Added coverage for supported price formats, discounted and original prices, unspecified or empty input, and whitespace edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->