### PR TITLE
Silence watchdog DEBUG logging to stop the docker debug loop (#354)

### DIFF
--- a/src/ai_marketplace_monitor/utils.py
+++ b/src/ai_marketplace_monitor/utils.py
@@ -1,6 +1,7 @@
 import copy
 import hashlib
 import json
+import logging
 import os
 import random
 import re
@@ -43,6 +44,14 @@ import rich.pretty
 from PIL import Image
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
+
+# watchdog's inotify buffer logs every filesystem event at DEBUG level
+# ("in-event <InotifyEvent ...>"). Because the log file lives inside the
+# watched configuration directory, each emitted log line triggers a new
+# filesystem event that is itself logged, producing a runaway debug loop
+# (see issue #354). Cap watchdog's own logger so its internal chatter can
+# never feed back into the application log.
+logging.getLogger("watchdog").setLevel(logging.WARNING)
 
 # home directory for all settings and caches
 amm_home = Path.home() / ".ai-marketplace-monitor"


### PR DESCRIPTION
## Problem

When running in the Docker container (or any setup where the log file lives inside the watched config directory), the log fills with thousands of:

```
DEBUG in-event <InotifyEvent: src_path=b'.../ai-marketplace-monitor.log', mask=IN_MODIFY ...>
```

`watchdog`'s inotify buffer logs **every** filesystem event at DEBUG. Because the log file sits **inside the watched directory**, each emitted log line modifies the file → triggers a new inotify event → which is itself logged → a runaway feedback loop. It floods the log file and the web UI live-log viewer, and wastes CPU/disk.

Reported in #354.

## Fix

Cap the `watchdog` logger to `WARNING` at import time (in `utils.py`, right where watchdog is imported). Its noisy internal inotify DEBUG chatter no longer reaches the application log. The application's own logging verbosity is unchanged.

One line + explanatory comment; no behavior change beyond suppressing watchdog's internal debug spam.

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented excessive internal file-monitoring activity and repetitive log output.
  * Improved application stability when monitoring configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->